### PR TITLE
Feature/TW-916: Parent locations of Location Tree need to be able to be checked

### DIFF
--- a/src/components/LocationsTree/index.js
+++ b/src/components/LocationsTree/index.js
@@ -99,6 +99,7 @@ const LocationsTree = ({
         onCheck={onCheck}
         treeData={locations}
         defaultExpandAll
+        checkStrictly
       />
       <AddFormModal
         locationPath={getLocationPath()}

--- a/src/containers/AccessPointDetails/components/Location/index.js
+++ b/src/containers/AccessPointDetails/components/Location/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Card, Form, Select } from 'antd';
 import Button from 'components/Button';
@@ -69,6 +69,7 @@ const Location = ({ locations, data, onUpdateEquipment }) => {
     form
       .validateFields()
       .then(newValues => {
+        console.log(newValues);
         if (newValues?.floor) {
           locationId = newValues.floor;
         } else if (newValues?.building) {
@@ -96,28 +97,27 @@ const Location = ({ locations, data, onUpdateEquipment }) => {
   };
 
   const handleOnChangeCity = value => {
-    form.setFieldsValue({ city: value, building: null, floor: null });
     setCity(locations.find(i => i.id === value));
     setBuilding(null);
     setFloor(null);
   };
 
   const handleOnChangeBuilding = value => {
-    form.setFieldsValue({ building: value, floor: null });
     setBuilding(city.children.find(i => i.id === value));
     setFloor(null);
   };
 
   const handleOnChangeFloor = value => {
-    form.setFieldsValue({ floor: value });
     setFloor(building.children.find(i => i.id === value));
   };
 
-  form.setFieldsValue({
-    city: city.id,
-    building: building && building.id,
-    floor: floor && floor.id,
-  });
+  useEffect(() => {
+    form.setFieldsValue({
+      city: city?.id,
+      building: building?.id,
+      floor: floor?.id,
+    });
+  }, [city, building, floor]);
 
   return (
     <Form {...layout} form={form}>
@@ -159,6 +159,7 @@ const Location = ({ locations, data, onUpdateEquipment }) => {
               className={styles.Field}
               placeholder="Select Location Building..."
               onChange={handleOnChangeBuilding}
+              allowClear
             >
               {Object.keys(city.children).map(i => (
                 <Option key={city.children[i].id} value={city.children[i].id}>
@@ -174,6 +175,7 @@ const Location = ({ locations, data, onUpdateEquipment }) => {
               className={styles.Field}
               placeholder="Select Location Floor..."
               onChange={handleOnChangeFloor}
+              allowClear
             >
               {Object.keys(building.children).map(i => (
                 <Option key={building.children[i].id} value={building.children[i].id}>

--- a/src/containers/AccessPointDetails/components/Location/index.js
+++ b/src/containers/AccessPointDetails/components/Location/index.js
@@ -69,7 +69,6 @@ const Location = ({ locations, data, onUpdateEquipment }) => {
     form
       .validateFields()
       .then(newValues => {
-        console.log(newValues);
         if (newValues?.floor) {
           locationId = newValues.floor;
         } else if (newValues?.building) {

--- a/src/containers/AccessPointDetails/components/Location/index.js
+++ b/src/containers/AccessPointDetails/components/Location/index.js
@@ -69,11 +69,11 @@ const Location = ({ locations, data, onUpdateEquipment }) => {
     form
       .validateFields()
       .then(newValues => {
-        if ('floor' in newValues) {
+        if (newValues?.floor) {
           locationId = newValues.floor;
-        } else if ('building' in newValues) {
+        } else if (newValues?.building) {
           locationId = newValues.building;
-        } else if ('city' in newValues) {
+        } else if (newValues?.city) {
           locationId = newValues.city;
         }
 


### PR DESCRIPTION
JIRA: [TW-916](https://connectustechnologies.atlassian.net/browse/TW-916)

## Description
*Can check only the Parent Tree Node (independent of the child nodes) to show APs of that immediate location. I.e. uncheck all children of node, but parent node will still be checked.*

### Before this PR
![Screen Shot 2020-07-23 at 12 47 39 PM](https://user-images.githubusercontent.com/64545886/88314402-e1220600-cce2-11ea-8c65-0d2013d3c972.png)
![Screen Shot 2020-07-23 at 12 47 58 PM](https://user-images.githubusercontent.com/64545886/88314388-dbc4bb80-cce2-11ea-9811-1a8d44d06ff9.png)

### After this PR
*![Screen Shot 2020-07-23 at 12 45 53 PM](https://user-images.githubusercontent.com/64545886/88314410-e2ebc980-cce2-11ea-87d2-c0b5e09f930b.png)*