### PR TITLE
hotfix/CAMI - removed CAMI crashes alert

### DIFF
--- a/src/containers/AccessPointDetails/components/OS/index.js
+++ b/src/containers/AccessPointDetails/components/OS/index.js
@@ -53,15 +53,12 @@ const OS = ({ data, osData, handleRefresh }) => {
 
   return (
     <Card title="Operating System Statistics" extra={<Timer handleRefresh={handleRefresh} />}>
-      <div className={styles.InlineBetweenDiv}>
-        <Alert
-          icon={<LineChartOutlined />}
-          message={`Up-time: ${convertDate(osPerformance.uptimeInSeconds)}`}
-          type="info"
-          showIcon
-        />
-      </div>
-
+      <Alert
+        icon={<LineChartOutlined />}
+        message={`Up-time: ${convertDate(osPerformance.uptimeInSeconds)}`}
+        type="info"
+        showIcon
+      />
       <div className={styles.InlineDiv} style={{ marginTop: '15px' }}>
         <SolidGauge data={cpu} title="Current CPU" />
         <SolidGauge data={memory} title="Current Free Memory" />

--- a/src/containers/AccessPointDetails/components/OS/index.js
+++ b/src/containers/AccessPointDetails/components/OS/index.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Card, Alert } from 'antd';
-import { InfoCircleOutlined, LineChartOutlined } from '@ant-design/icons';
+import { LineChartOutlined } from '@ant-design/icons';
 
 import SolidGauge from './components/SolidGauge';
 import HighChartGraph from './components/HighChartGraph';
@@ -57,12 +57,6 @@ const OS = ({ data, osData, handleRefresh }) => {
         <Alert
           icon={<LineChartOutlined />}
           message={`Up-time: ${convertDate(osPerformance.uptimeInSeconds)}`}
-          type="info"
-          showIcon
-        />
-        <Alert
-          icon={<InfoCircleOutlined />}
-          message={`CAMI crashes since boot: ${osPerformance.numCamiCrashes}`}
           type="info"
           showIcon
         />


### PR DESCRIPTION
JIRA: [ID](LINK)

## Description
*Removed CAMI crashes alert on OS stats page*

### Before this PR
*Screenshots of what it looked like before this PR
![Screen Shot 2020-07-30 at 2 02 40 PM](https://user-images.githubusercontent.com/55258316/88978659-253a7b00-d28e-11ea-8eb8-4c72303dec32.png)
*

### After this PR
*Screenshots of what it will look like after this PR
![image](https://user-images.githubusercontent.com/55258316/88978643-1b187c80-d28e-11ea-9293-3c8e1e8af758.png)

*