### PR TITLE
hotfix/WIFI-770: Moved Service Zone buttons to be visible

### DIFF
--- a/src/containers/ProfileDetails/components/Radius/index.js
+++ b/src/containers/ProfileDetails/components/Radius/index.js
@@ -403,21 +403,21 @@ const RadiusForm = ({ form, details }) => {
                 extra={
                   <>
                     <>
-                          <b className={styles.iconButton}>{item.name}</b>
-                          <Button
-                            title="editRadiusServiceZone"
-                            onClick={() => handleEditZone(item)}
-                            className={styles.iconButton}
-                            icon={<EditOutlined />}
-                          />
-                          <Button
-                            title="deleteRadiusServiceZone"
-                            onClick={() => handleDeleteZone(item)}
-                            className={styles.iconButton}
-                            icon={<DeleteOutlined />}
-                            type="danger"
-                          />
-                        </>
+                      <b className={styles.iconButton}>{item.name}</b>
+                        <Button
+                          title="editRadiusServiceZone"
+                          onClick={() => handleEditZone(item)}
+                          className={styles.iconButton}
+                          icon={<EditOutlined />}
+                        />
+                        <Button
+                          title="deleteRadiusServiceZone"
+                          onClick={() => handleDeleteZone(item)}
+                          className={styles.iconButton}
+                          icon={<DeleteOutlined />}
+                          type="danger"
+                        />
+                    </>
                     <div className={styles.RadiusInline}>
                       <Card className={styles.infoCard} title=" Radius Services" bordered={false}>
                         <Table

--- a/src/containers/ProfileDetails/components/Radius/index.js
+++ b/src/containers/ProfileDetails/components/Radius/index.js
@@ -411,6 +411,22 @@ const RadiusForm = ({ form, details }) => {
                           size="small"
                           rowKey="name"
                         />
+                        <>
+                          <b className={styles.iconButton}>{item.name}</b>
+                          <Button
+                            title="editRadiusServiceZone"
+                            onClick={() => handleEditZone(item)}
+                            className={styles.iconButton}
+                            icon={<EditOutlined />}
+                          />
+                          <Button
+                            title="deleteRadiusServiceZone"
+                            onClick={() => handleDeleteZone(item)}
+                            className={styles.iconButton}
+                            icon={<DeleteOutlined />}
+                            type="danger"
+                          />
+                        </>
                       </Card>
 
                       <Card className={styles.infoCard} title=" Management Subset" bordered={false}>
@@ -433,28 +449,7 @@ const RadiusForm = ({ form, details }) => {
                     </div>
                   </>
                 }
-              >
-                <List.Item.Meta
-                  title={
-                    <>
-                      <b className={styles.iconButton}>{item.name}</b>
-                      <Button
-                        title="editRadiusServiceZone"
-                        onClick={() => handleEditZone(item)}
-                        className={styles.iconButton}
-                        icon={<EditOutlined />}
-                      />
-                      <Button
-                        title="deleteRadiusServiceZone"
-                        onClick={() => handleDeleteZone(item)}
-                        className={styles.iconButton}
-                        icon={<DeleteOutlined />}
-                        type="danger"
-                      />
-                    </>
-                  }
-                />
-              </List.Item>
+              />
             )}
           />
         </Panel>

--- a/src/containers/ProfileDetails/components/Radius/index.js
+++ b/src/containers/ProfileDetails/components/Radius/index.js
@@ -402,16 +402,7 @@ const RadiusForm = ({ form, details }) => {
                 aria-label={`serviceZoneItem-${item.name}`}
                 extra={
                   <>
-                    <div className={styles.RadiusInline}>
-                      <Card className={styles.infoCard} title=" Radius Services" bordered={false}>
-                        <Table
-                          dataSource={services}
-                          columns={columns}
-                          pagination={false}
-                          size="small"
-                          rowKey="name"
-                        />
-                        <>
+                    <>
                           <b className={styles.iconButton}>{item.name}</b>
                           <Button
                             title="editRadiusServiceZone"
@@ -427,6 +418,15 @@ const RadiusForm = ({ form, details }) => {
                             type="danger"
                           />
                         </>
+                    <div className={styles.RadiusInline}>
+                      <Card className={styles.infoCard} title=" Radius Services" bordered={false}>
+                        <Table
+                          dataSource={services}
+                          columns={columns}
+                          pagination={false}
+                          size="small"
+                          rowKey="name"
+                        />
                       </Card>
 
                       <Card className={styles.infoCard} title=" Management Subset" bordered={false}>

--- a/src/containers/ProfileDetails/components/index.module.scss
+++ b/src/containers/ProfileDetails/components/index.module.scss
@@ -48,10 +48,19 @@
     width: 100%;
   }
 
-  :global(.ant-collapse-header) {
-    font-size: 16px;
-    padding-top: 18px !important;
-    padding-bottom: 10px !important;
+  :global(div.ant-collapse-header) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  :global(.ant-collapse .ant-collapse-item .ant-collapse-header::before), 
+  :global(.ant-collapse .ant-collapse-item .ant-collapse-header::after) {
+    content: none;
+  }
+
+  :global(div.ant-collapse-header div button) {
+    margin-bottom: 0px;
   }
 }
 

--- a/src/containers/ProfileDetails/components/index.module.scss
+++ b/src/containers/ProfileDetails/components/index.module.scss
@@ -52,6 +52,10 @@
     font-size: 16px;
     transform: translate(0, 10%);
   }
+
+  :global(.ant-collapse-arrow) {
+    transform: translateY(-100%) !important;
+  }
 }
 
 .FlexDiv {

--- a/src/containers/ProfileDetails/components/index.module.scss
+++ b/src/containers/ProfileDetails/components/index.module.scss
@@ -50,11 +50,8 @@
 
   :global(.ant-collapse-header) {
     font-size: 16px;
-    transform: translate(0, 10%);
-  }
-
-  :global(.ant-collapse-arrow) {
-    transform: translateY(-100%) !important;
+    padding-top: 18px !important;
+    padding-bottom: 10px !important;
   }
 }
 

--- a/src/containers/ProfileDetails/components/index.module.scss
+++ b/src/containers/ProfileDetails/components/index.module.scss
@@ -47,6 +47,11 @@
   :global(.ant-upload.ant-upload-select-picture-card) {
     width: 100%;
   }
+
+  :global(.ant-collapse-header) {
+    font-size: 16px;
+    transform: translate(0, 10%);
+  }
 }
 
 .FlexDiv {


### PR DESCRIPTION
JIRA: [WIFI-770](https://telecominfraproject.atlassian.net/browse/WIFI-770)

## Description
Location of Service Zone and its Edit button & Remove button were visibly blocked by Radius Service table. Moved this information into it's down column beside table so they are no longer blocked

Additionally centered Collapse Title and Collapse arrow and modified the font's to match the other cards


### Before this PR
*Screenshots of what it looked like before this PR*
<img width="1792" alt="Screen Shot 2020-09-15 at 11 47 52 AM" src="https://user-images.githubusercontent.com/70719869/93234139-ec753900-f749-11ea-9321-f478e71f3d58.png">


### After this PR
*Screenshots of what it will look like after this PR*
<img width="1792" alt="Screen Shot 2020-09-15 at 4 48 52 PM" src="https://user-images.githubusercontent.com/70719869/93263926-6d492a80-f774-11ea-955f-56bebcdb9d23.png">

