### PR TITLE
hotfix/wifi-777: Added option to create a Radius Profile

### DIFF
--- a/src/containers/AddProfile/index.js
+++ b/src/containers/AddProfile/index.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
-import { Form, Input, Card, Select } from 'antd';
+import { Form, Input, Card, Select, notification } from 'antd';
 import { LeftOutlined } from '@ant-design/icons';
 
 import Button from 'components/Button';
@@ -77,6 +77,21 @@ const AddProfile = ({ onCreateProfile, ssidProfiles, onFetchMoreProfiles }) => {
         }
 
         if (profileType === 'radius') {
+          if (values.services.length === 0) {
+            notification.error({
+              message: 'Error',
+              description: 'At least 1 RADIUS Service is required.',
+            });
+            return;
+          }
+          if (values.zones.length === 0) {
+            notification.error({
+              message: 'Error',
+              description: 'At least 1 RADIUS Service Zone is required.',
+            });
+            return;
+          }
+          
           formattedData.model_type = 'RadiusProfile';
           formattedData = Object.assign(formattedData, formatRadiusForm(values));
         }
@@ -150,12 +165,7 @@ const AddProfile = ({ onCreateProfile, ssidProfiles, onFetchMoreProfiles }) => {
             />
           )}
           {profileType === 'bonjour' && <BonjourGatewayForm form={form} />}
-          {profileType === 'radius' && (
-            <RadiusForm 
-              form={form} 
-              details={{}} 
-            />
-          )}
+          {profileType === 'radius' && <RadiusForm form={form} />}
         </Form>
       </div>
     </Container>

--- a/src/containers/AddProfile/index.js
+++ b/src/containers/AddProfile/index.js
@@ -176,13 +176,11 @@ AddProfile.propTypes = {
   onCreateProfile: PropTypes.func.isRequired,
   ssidProfiles: PropTypes.instanceOf(Array),
   onFetchMoreProfiles: PropTypes.func,
-  radiusProfiles: PropTypes.instanceOf(Array),
 };
 
 AddProfile.defaultProps = {
   ssidProfiles: [],
   onFetchMoreProfiles: () => {},
-  radiusProfiles: [],
 };
 
 export default AddProfile;

--- a/src/containers/AddProfile/index.js
+++ b/src/containers/AddProfile/index.js
@@ -13,6 +13,7 @@ import {
   formatSsidProfileForm,
   formatApProfileForm,
   formatBonjourGatewayForm,
+  formatRadiusForm,
 } from 'utils/profiles';
 
 import globalStyles from 'styles/index.scss';
@@ -21,6 +22,7 @@ import styles from './index.module.scss';
 import SSIDForm from '../ProfileDetails/components/SSID';
 import AccessPointForm from '../ProfileDetails/components/AccessPoint';
 import BonjourGatewayForm from '../ProfileDetails/components/BonjourGateway';
+import RadiusForm from '../ProfileDetails/components/Radius';
 
 const { Item } = Form;
 const { Option } = Select;
@@ -74,6 +76,11 @@ const AddProfile = ({ onCreateProfile, ssidProfiles, onFetchMoreProfiles }) => {
           formattedData = Object.assign(formattedData, formatBonjourGatewayForm(values));
         }
 
+        if (profileType === 'radius') {
+          formattedData.model_type = 'RadiusProfile';
+          formattedData = Object.assign(formattedData, formatRadiusForm(values));
+        }
+
         onCreateProfile(profileType, name, formattedData, formattedData.childProfileIds);
         setIsFormDirty(false);
       })
@@ -122,6 +129,7 @@ const AddProfile = ({ onCreateProfile, ssidProfiles, onFetchMoreProfiles }) => {
                 <Option value="ssid">SSID</Option>
                 <Option value="equipment_ap">Access Point</Option>
                 <Option value="bonjour">Bonjour Gateway</Option>
+                <Option value="radius">Radius</Option>
               </Select>
             </Item>
             <Item
@@ -142,6 +150,12 @@ const AddProfile = ({ onCreateProfile, ssidProfiles, onFetchMoreProfiles }) => {
             />
           )}
           {profileType === 'bonjour' && <BonjourGatewayForm form={form} />}
+          {profileType === 'radius' && (
+            <RadiusForm 
+              form={form} 
+              details={{}} 
+            />
+          )}
         </Form>
       </div>
     </Container>
@@ -152,11 +166,13 @@ AddProfile.propTypes = {
   onCreateProfile: PropTypes.func.isRequired,
   ssidProfiles: PropTypes.instanceOf(Array),
   onFetchMoreProfiles: PropTypes.func,
+  radiusProfiles: PropTypes.instanceOf(Array),
 };
 
 AddProfile.defaultProps = {
   ssidProfiles: [],
   onFetchMoreProfiles: () => {},
+  radiusProfiles: [],
 };
 
 export default AddProfile;

--- a/src/containers/ProfileDetails/components/Radius/components/RadiusZone/index.js
+++ b/src/containers/ProfileDetails/components/Radius/components/RadiusZone/index.js
@@ -7,7 +7,6 @@ import styles from '../../../index.module.scss';
 const RadiusZoneModal = ({ onSuccess, onCancel, visible, title, zone }) => {
   const { Item } = Form;
   const [form] = Form.useForm();
-  form.resetFields();
 
   const layout = {
     labelCol: { span: 8 },

--- a/src/containers/ProfileDetails/components/Radius/index.js
+++ b/src/containers/ProfileDetails/components/Radius/index.js
@@ -134,9 +134,10 @@ const RadiusForm = ({ form, details }) => {
       zones.map(i => {
         if (i.name === item.serviceRegionName) {
           return {
+            ...i,
             subnets: i?.subnets ? [...i.subnets, item] : [item],
           };
-        }  
+        }
         return i;
       })
     );

--- a/src/containers/ProfileDetails/components/Radius/index.js
+++ b/src/containers/ProfileDetails/components/Radius/index.js
@@ -111,7 +111,7 @@ const RadiusForm = ({ form, details }) => {
   const handleEditZoneSuccess = item => {
     setZones(
       zones.map(i => {
-        if (i.name === selectedZone.name) {
+        if (i.name === item.name) {
           return item;
         }
         return i;
@@ -132,10 +132,15 @@ const RadiusForm = ({ form, details }) => {
   const handleAddSubnetSuccess = item => {
     setZones(
       zones.map(i => {
-        if (i.name === item.serviceRegionName) {
+        if (i.name === item.serviceRegionName && 'subnets' in i) {
           return {
             ...i,
             subnets: [...i.subnets, item],
+          };
+        }  
+        if (i.name === item.serviceRegionName) {
+          return {
+            ...i, subnets: [item],
           };
         }
         return i;

--- a/src/containers/ProfileDetails/components/Radius/index.js
+++ b/src/containers/ProfileDetails/components/Radius/index.js
@@ -132,17 +132,11 @@ const RadiusForm = ({ form, details }) => {
   const handleAddSubnetSuccess = item => {
     setZones(
       zones.map(i => {
-        if (i.name === item.serviceRegionName && 'subnets' in i) {
-          return {
-            ...i,
-            subnets: [...i.subnets, item],
-          };
-        }  
         if (i.name === item.serviceRegionName) {
           return {
-            ...i, subnets: [item],
+            subnets: i?.subnets ? [...i.subnets, item] : [item],
           };
-        }
+        }  
         return i;
       })
     );


### PR DESCRIPTION
JIRA: [WIFI-777](https://telecominfraproject.atlassian.net/browse/WIFI-777)

## Description
*Summary of this PR*
- Added option to create a Radius profile under in addProfile 
- Added notifications to ensure details of the Radius form are filled properly
- Removed `Cannot update during an existing state transition (such as within `render`).` warning in RadiusZoneModal 
- Fixed newly found bug where subnet could not be added following a newly made Service Zone, now radius forms can be submitted smoothly

### Before this PR
*Screenshots of what it looked like before this PR*
<img width="1792" alt="Screen Shot 2020-09-18 at 3 59 54 PM" src="https://user-images.githubusercontent.com/70719869/93640740-15573180-f9c9-11ea-8c92-3d75e30894f1.png">


### After this PR
*Screenshots of what it will look like after this PR*
<img width="1792" alt="Screen Shot 2020-09-18 at 3 58 00 PM" src="https://user-images.githubusercontent.com/70719869/93640755-1e480300-f9c9-11ea-8732-f981c4e1c7ee.png">
<img width="1792" alt="Screen Shot 2020-09-18 at 3 58 21 PM" src="https://user-images.githubusercontent.com/70719869/93640761-21db8a00-f9c9-11ea-8c0c-aad56ce0c094.png">
