### PR TITLE
hotfix/WIFI-800: Updated values of channel bandwidth & Radio mode & removed 80Ghz option for 2.4GHz radio

### DIFF
--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -74,7 +74,8 @@ const General = ({
     form
       .validateFields()
       .then(values => {
-        const formattedData = { ...data.details };
+        const formattedData = JSON.parse(JSON.stringify({ ...data.details }));
+        
         Object.keys(formattedData.radioMap).forEach(radio => {
           Object.keys(formattedData.radioMap[radio]).forEach(field => {
             if (field === 'neighbouringListApConfig') {
@@ -204,7 +205,7 @@ const General = ({
         },
       ]}
     >
-      {options.dropdown}
+      {dataIndex === 'channelBandwidth' && key === 'is2dot4GHz' ? options.dropdown2 : options.dropdown}
     </Item>
   );
 
@@ -372,9 +373,9 @@ const General = ({
           {renderItem('Radio Mode', data.details.advancedRadioMap, 'radioMode', renderOptionItem, {
             dropdown: (
               <Select className={styles.Field}>
-                <Option value="BGN">BGN</Option>
-                <Option value="N">N</Option>
-                <Option value="AC">AC</Option>
+                <Option value="modeBGN">modeBGN</Option>
+                <Option value="modeN">modeN</Option>
+                <Option value="modeAC">modeAC</Option>
               </Select>
             ),
           })}
@@ -406,11 +407,19 @@ const General = ({
             {
               dropdown: (
                 <Select className={styles.Field}>
-                  <Option value="20MHz">20MHz</Option>
-                  <Option value="40MHz">40MHz</Option>
+                  <Option value="is20MHz">is20MHz</Option>
+                  <Option value="is40MHz">is40MHz</Option>
+                  <Option value="is80MHz">is80MHz</Option>
                 </Select>
               ),
-            }
+
+              dropdown2: (
+                <Select className={styles.Field}>
+                  <Option value="is20MHz">is20MHz</Option>
+                  <Option value="is40MHz">is40MHz</Option>
+                </Select>
+              ),
+            },
           )}
           <p>Radio Resource Management:</p>
 

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -408,7 +408,6 @@ const General = ({
                 <Select className={styles.Field}>
                   <Option value="20MHz">20MHz</Option>
                   <Option value="40MHz">40MHz</Option>
-                  <Option value="80MHz">80MHz</Option>
                 </Select>
               ),
             }

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -414,9 +414,9 @@ const General = ({
               dropdown: (key) => {
                 return (
                 <Select className={styles.Field}>
-                  <Option value="is20MHz">is20MHz</Option>
-                  <Option value="is40MHz">is40MHz</Option>
-                  {key === 'is2dot4GHz' ? null : <Option value="is80MHz">is80MHz</Option>}
+                  <Option value="is20MHz">20MHz</Option>
+                  <Option value="is40MHz">40MHz</Option>
+                  {key === 'is2dot4GHz' ? null : <Option value="is80MHz">80MHz</Option>}
                 </Select>
                 );
               },

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -77,7 +77,7 @@ const General = ({
       .validateFields()
       .then(values => {
         const formattedData = _.cloneDeep(data.details);
-        
+
         Object.keys(formattedData.radioMap).forEach(radio => {
           Object.keys(formattedData.radioMap[radio]).forEach(field => {
             if (field === 'neighbouringListApConfig') {
@@ -211,7 +211,7 @@ const General = ({
         },
       ]}
     >
-      {dataIndex === 'channelBandwidth' && key === 'is2dot4GHz' ? options.dropdown2 : options.dropdown}
+      {typeof options.dropdown === 'function' ? options.dropdown(key) : options.dropdown}
     </Item>
   );
 
@@ -379,9 +379,9 @@ const General = ({
           {renderItem('Radio Mode', data.details.advancedRadioMap, 'radioMode', renderOptionItem, {
             dropdown: (
               <Select className={styles.Field}>
-                <Option value="modeBGN">modeBGN</Option>
-                <Option value="modeN">modeN</Option>
-                <Option value="modeAC">modeAC</Option>
+                <Option value="modeBGN">BGN</Option>
+                <Option value="modeN">N</Option>
+                <Option value="modeAC">AC</Option>
               </Select>
             ),
           })}
@@ -411,20 +411,15 @@ const General = ({
             'channelBandwidth',
             renderOptionItem,
             {
-              dropdown: (
+              dropdown: (key) => {
+                return (
                 <Select className={styles.Field}>
                   <Option value="is20MHz">is20MHz</Option>
                   <Option value="is40MHz">is40MHz</Option>
-                  <Option value="is80MHz">is80MHz</Option>
+                  {key === 'is2dot4GHz' ? null : <Option value="is80MHz">is80MHz</Option>}
                 </Select>
-              ),
-
-              dropdown2: (
-                <Select className={styles.Field}>
-                  <Option value="is20MHz">is20MHz</Option>
-                  <Option value="is40MHz">is40MHz</Option>
-                </Select>
-              ),
+                );
+              },
             },
           )}
           <p>Radio Resource Management:</p>


### PR DESCRIPTION
JIRA: [WIFI-800](https://telecominfraproject.atlassian.net/browse/WIFI-800)

## Description
*Summary of this PR*
-Updated to the values & selection option for Channel Bandwidth to be is20MHz, is40MHz, and is80MHz
-Updated the values & selection option for Radio mode to be modeBGN, modeN, modeAC
- Remove dropdown option to select 80Mhz from 2.4Ghz Channel Bandwidth 
-Fixed save bug, the AP general page can now be updated and saved properly

### Before this PR
*Screenshots of what it looked like before this PR*
<img width="1792" alt="Screen Shot 2020-09-21 at 2 45 59 PM" src="https://user-images.githubusercontent.com/70719869/93808127-94db3f80-fc19-11ea-88a8-7d7a9802e723.png">
<img width="1792" alt="Screen Shot 2020-09-22 at 2 54 27 PM" src="https://user-images.githubusercontent.com/70719869/93925186-c4ef1500-fce3-11ea-9583-8aa9a892a043.png">



### After this PR
*Screenshots of what it will look like after this PR*
<img width="1792" alt="Screen Shot 2020-09-21 at 2 45 18 PM" src="https://user-images.githubusercontent.com/70719869/93808153-9d337a80-fc19-11ea-8cb2-fe35e8199364.png">
<img width="1792" alt="Screen Shot 2020-09-22 at 2 53 40 PM" src="https://user-images.githubusercontent.com/70719869/93925199-ccaeb980-fce3-11ea-89cd-e1f553dd7c0c.png">

