### PR TITLE
hotfix/WIFI-844: Fixed disabling of the delete button of the select model in use

### DIFF
--- a/src/containers/Firmware/index.js
+++ b/src/containers/Firmware/index.js
@@ -233,7 +233,7 @@ const Firmware = ({
       width: 60,
       render: (_, record) => {
         const found = Object.values(trackAssignmentData).some(
-          i => Object.values(record).indexOf(i.modelId) > 0
+          i => Object.values(record).indexOf(i.firmwareVersionRecordId) > 0
         );
         return !found ? (
           <Button


### PR DESCRIPTION
JIRA: [WIFI-844](https://telecominfraproject.atlassian.net/browse/WIFI-844)

## Description
*Summary of this PR*
- in the All Version table, disabled delete button of the version that is currently in use (in the Model Target Version table)

### Before this PR
*Screenshots of what it looked like before this PR*
<img width="1792" alt="Screen Shot 2020-09-28 at 5 10 44 PM" src="https://user-images.githubusercontent.com/70719869/94486801-e9e4fb80-01ad-11eb-807b-e267b3d8d16d.png">


### After this PR
*Screenshots of what it will look like after this PR*
<img width="1792" alt="Screen Shot 2020-09-28 at 5 08 55 PM" src="https://user-images.githubusercontent.com/70719869/94486820-f10c0980-01ad-11eb-980e-5227c3d2156b.png">
