### PR TITLE
hotfix/WIFI-811: Fixed captive_portal Profile's allow list to no longer be case sensitive

### DIFF
--- a/src/containers/ProfileDetails/components/CaptivePortal/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/index.js
@@ -124,7 +124,7 @@ const CaptivePortalForm = ({
   };
 
   const validateWhitelist = (_rule, value) => {
-    let inputString = value.trim();
+    let inputString = value.toLowerCase().trim();
 
     if (inputString.match(/[a-z]/i)) {
       // contains letters, so validate as hostname
@@ -232,7 +232,7 @@ const CaptivePortalForm = ({
 
   const handleOnWhitelist = value => {
     validateWhitelist(null, value).then(() => {
-      setWhitelist([...whitelist, value.trim()]);
+      setWhitelist([...whitelist, value.toLowerCase().trim()]);
       setWhitelistSearch('');
       setWhitelistValidation({
         status: null,


### PR DESCRIPTION
JIRA: [WIFI-811](https://telecominfraproject.atlassian.net/browse/WIFI-811)

## Description
*Summary of this PR*
- sets the url inputs as lower case when added & validates url input as lower case, to be no longer case sensitive

### Before this PR
*Screenshots of what it looked like before this PR*
<img width="1792" alt="Screen Shot 2020-09-29 at 2 50 07 PM" src="https://user-images.githubusercontent.com/70719869/94602627-1c9cfb80-0263-11eb-84a4-9e8e8bb8cd58.png">


### After this PR
*Screenshots of what it will look like after this PR*
<img width="1792" alt="Screen Shot 2020-09-29 at 2 42 54 PM" src="https://user-images.githubusercontent.com/70719869/94602639-2292dc80-0263-11eb-82d3-19a630a173ed.png">
