### PR TITLE
hotfix/WIFI-820: fixed external splash page URL save issue

### DIFF
--- a/src/containers/ProfileDetails/components/CaptivePortal/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/index.js
@@ -440,7 +440,6 @@ const CaptivePortalForm = ({
       {externalSplash && (
         <Card title="External Splash Page">
           <Item
-            name="externalCaptivePortalURL"
             label="URL"
             rules={[
               {
@@ -451,7 +450,7 @@ const CaptivePortalForm = ({
             ]}
           >
             <div className={styles.InlineDiv}>
-              <Input className={globalStyles.field} placeholder="http://... or https://..." />
+              <Input className={globalStyles.field} placeholder="http://... or https://..." defaultValue={details.externalCaptivePortalURL}/>
               <Button onClick={() => setShowTips(!showTips)} icon={<QuestionCircleFilled />}>
                 {!showTips ? 'Show Splash Page Tips' : 'Hide Splash Page Tips'}
               </Button>

--- a/src/containers/ProfileDetails/components/CaptivePortal/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/index.js
@@ -439,24 +439,25 @@ const CaptivePortalForm = ({
       )}
       {externalSplash && (
         <Card title="External Splash Page">
-          <Item
-              name="externalCaptivePortalURL"
-              label="URL"
-              rules={[
-                {
-                  required: externalSplash,
-                  type: 'url',
-                  message: 'Please enter URL in the format http://... or https://...',
-                },
-              ]}
-          > 
-            <Input className={globalStyles.field} placeholder="http://... or https://..." 
-             addonAfter={
-              <Button className={styles.SplashInfo}onClick={() => setShowTips(!showTips)} icon={<QuestionCircleFilled />}>
+          <Item label="URL">
+            <div className={styles.InlineDiv}>
+              <Item
+                noStyle
+                name="externalCaptivePortalURL"
+                rules={[
+                  {
+                    required: externalSplash,
+                    type: 'url',
+                    message: 'Please enter URL in the format http://... or https://...',
+                  },
+                ]}
+              >
+                <Input className={globalStyles.field} placeholder="http://... or https://..." />
+              </Item>
+              <Button onClick={() => setShowTips(!showTips)} icon={<QuestionCircleFilled />}>
                 {!showTips ? 'Show Splash Page Tips' : 'Hide Splash Page Tips'}
               </Button>
-             } 
-            />
+            </div>
           </Item>
           {showTips && (
             <Alert

--- a/src/containers/ProfileDetails/components/CaptivePortal/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/index.js
@@ -439,24 +439,24 @@ const CaptivePortalForm = ({
       )}
       {externalSplash && (
         <Card title="External Splash Page">
-          <Item
-            name="externalCaptivePortalURL"
-            label="URL"
-            rules={[
-              {
-                required: externalSplash,
-                type: 'url',
-                message: 'Please enter URL in the format http://... or https://...',
-              },
-            ]}
-          >
-            <div className={styles.InlineDiv}>
-              <Input className={globalStyles.field} placeholder="http://... or https://..." defaultValue={details.externalCaptivePortalURL}/>
-              <Button onClick={() => setShowTips(!showTips)} icon={<QuestionCircleFilled />}>
-                {!showTips ? 'Show Splash Page Tips' : 'Hide Splash Page Tips'}
-              </Button>
-            </div>
-          </Item>
+          <div className={styles.InlineDiv}>
+            <Item
+              name="externalCaptivePortalURL"
+              label="URL"
+              rules={[
+                {
+                  required: externalSplash,
+                  type: 'url',
+                  message: 'Please enter URL in the format http://... or https://...',
+                },
+              ]}
+            > 
+              <Input className={globalStyles.field} placeholder="http://... or https://..." />
+            </Item>
+            <Button onClick={() => setShowTips(!showTips)} icon={<QuestionCircleFilled />}>
+              {!showTips ? 'Show Splash Page Tips' : 'Hide Splash Page Tips'}
+            </Button>
+          </div>
           {showTips && (
             <Alert
               className={globalStyles.field}

--- a/src/containers/ProfileDetails/components/CaptivePortal/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/index.js
@@ -439,8 +439,7 @@ const CaptivePortalForm = ({
       )}
       {externalSplash && (
         <Card title="External Splash Page">
-          <div className={styles.InlineDiv}>
-            <Item
+          <Item
               name="externalCaptivePortalURL"
               label="URL"
               rules={[
@@ -450,13 +449,15 @@ const CaptivePortalForm = ({
                   message: 'Please enter URL in the format http://... or https://...',
                 },
               ]}
-            > 
-              <Input className={globalStyles.field} placeholder="http://... or https://..." />
-            </Item>
-            <Button onClick={() => setShowTips(!showTips)} icon={<QuestionCircleFilled />}>
-              {!showTips ? 'Show Splash Page Tips' : 'Hide Splash Page Tips'}
-            </Button>
-          </div>
+          > 
+            <Input className={globalStyles.field} placeholder="http://... or https://..." 
+             addonAfter={
+              <Button className={styles.SplashInfo}onClick={() => setShowTips(!showTips)} icon={<QuestionCircleFilled />}>
+                {!showTips ? 'Show Splash Page Tips' : 'Hide Splash Page Tips'}
+              </Button>
+             } 
+            />
+          </Item>
           {showTips && (
             <Alert
               className={globalStyles.field}

--- a/src/containers/ProfileDetails/components/CaptivePortal/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/index.js
@@ -440,6 +440,7 @@ const CaptivePortalForm = ({
       {externalSplash && (
         <Card title="External Splash Page">
           <Item
+            name="externalCaptivePortalURL"
             label="URL"
             rules={[
               {

--- a/src/containers/ProfileDetails/components/index.module.scss
+++ b/src/containers/ProfileDetails/components/index.module.scss
@@ -62,6 +62,11 @@
   :global(div.ant-collapse-header div button) {
     margin-bottom: 0px;
   }
+
+  :global(div:nth-child(2) > div.ant-card-body .ant-input-group-addon){
+    background: #141414;
+    border: none;
+  }
 }
 
 .FlexDiv {

--- a/src/containers/ProfileDetails/components/index.module.scss
+++ b/src/containers/ProfileDetails/components/index.module.scss
@@ -62,11 +62,6 @@
   :global(div.ant-collapse-header div button) {
     margin-bottom: 0px;
   }
-
-  :global(div:nth-child(2) > div.ant-card-body .ant-input-group-addon){
-    background: #141414;
-    border: none;
-  }
 }
 
 .FlexDiv {


### PR DESCRIPTION
JIRA: [WIFI-820](https://telecominfraproject.atlassian.net/browse/WIFI-820)

## Description
*Summary of this PR*
- externalCaptivePortalURL was saving properly but not displaying in form w antd Form.Item `name` keyword due to being wrapped in a <div>
- used antd Input `defaultValue` keyword to display the saved url
-update name keyword is need for rules to be applied, added it back

### Before this PR
*Screenshots of what it looked like before this PR*
<img width="1792" alt="Screen Shot 2020-09-30 at 10 49 24 AM" src="https://user-images.githubusercontent.com/70719869/94701462-ad7ae200-030a-11eb-87ad-0fc985c2f6b3.png">


### After this PR
*Screenshots of what it will look like after this PR*
<img width="1792" alt="Screen Shot 2020-09-30 at 11 13 45 AM" src="https://user-images.githubusercontent.com/70719869/94704612-1748bb00-030e-11eb-8663-0f18ed0b3343.png">


