### PR TITLE
hotfix/WIFI-774: Fixed alias form.item to display only when correct OUI searched

### DIFF
--- a/src/containers/Manufacturer/index.js
+++ b/src/containers/Manufacturer/index.js
@@ -126,7 +126,7 @@ const Manufacturer = ({ onSearchOUI, onUpdateOUI, returnedOUI, fileUpload }) => 
                 onSearch={handleOnSearch}
               />
             </Item>
-            {returnedOUI && !cancel && (
+            {returnedOUI?.oui && !cancel && (
               <>
                 <Item label="Manufacturer">{returnedOUI.manufacturerName}</Item>
                 <Item


### PR DESCRIPTION
JIRA: [WIFI-774](https://telecominfraproject.atlassian.net/browse/WIFI-774)

## Description
*Summary of this PR*
- only renders the Form.Item to set an Alias for OUI only when a correct OUI is searched, when `returnedOUI.oui` property is not null
- this PR is linked with the WIFI-774 PR in the library

### Before this PR
*Screenshots of what it looked like before this PR*
<img width="1792" alt="Screen Shot 2020-10-02 at 1 28 44 PM" src="https://user-images.githubusercontent.com/70719869/94954914-c4ab0280-04b7-11eb-9609-fde42c96b4f3.png">

### After this PR
*Screenshots of what it will look like after this PR*
<img width="1792" alt="Screen Shot 2020-10-02 at 1 27 48 PM" src="https://user-images.githubusercontent.com/70719869/94954940-ce346a80-04b7-11eb-8731-f8b6e14a7305.png">

<img width="1792" alt="Screen Shot 2020-10-02 at 2 02 23 PM" src="https://user-images.githubusercontent.com/70719869/94955015-edcb9300-04b7-11eb-9e45-6a7f3da4e4c3.png">

