### PR TITLE
hotfix/WIFI-822: Fixed splash page Radio button save issue

### DIFF
--- a/src/containers/ProfileDetails/index.js
+++ b/src/containers/ProfileDetails/index.js
@@ -101,6 +101,9 @@ const ProfileDetails = ({
           formattedData = Object.assign(formattedData, formatRadiusForm(values));
         }
         if (profileType === 'captive_portal') {
+          if (!values?.externalCaptivePortalURL){
+            formattedData.externalCaptivePortalURL = null;
+          }
           formattedData = Object.assign(formattedData, formatCaptiveForm(values, details));
         }
 
@@ -108,7 +111,6 @@ const ProfileDetails = ({
           formattedData.model_type = 'BonjourGatewayProfile';
           formattedData = Object.assign(formattedData, formatBonjourGatewayForm(values));
         }
-
         onUpdateProfile(values.name, formattedData, formattedData.childProfileIds);
         setIsFormDirty(false);
       })

--- a/src/containers/ProfileDetails/index.js
+++ b/src/containers/ProfileDetails/index.js
@@ -101,9 +101,6 @@ const ProfileDetails = ({
           formattedData = Object.assign(formattedData, formatRadiusForm(values));
         }
         if (profileType === 'captive_portal') {
-          if (!values?.externalCaptivePortalURL){
-            formattedData.externalCaptivePortalURL = null;
-          }
           formattedData = Object.assign(formattedData, formatCaptiveForm(values, details));
         }
 

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -162,5 +162,9 @@ export const formatCaptiveForm = (values, details) => {
     formattedData.backgroundFile = details.backgroundFile;
   }
 
+  if (!values?.externalCaptivePortalURL){
+    formattedData.externalCaptivePortalURL = null;
+  }
+
   return formattedData;
 };


### PR DESCRIPTION
JIRA: [WIFI-822](https://telecominfraproject.atlassian.net/browse/WIFI-822)

## Description
*Summary of this PR*
Issue
- radio button was not saving properly because `externalCaptivePortalURL` property is not being reset
- on save, the values of the current form are taken to be saved, if Access Point Hosted is selected `Form.Item` for  `externalCaptivePortalURL` does exist/appear in form thus cannot be reset
- CaptivePortal page is set up to check if `externalCaptivePortalURL` exist to select Externally Hosted on load

Solution
- on save check if the current form has value of `externalCaptivePortalURL` meaning Access Point Hosted is selected. then set the `externalCaptivePortalURL` in formattedData to be null

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*