### PR TITLE
hotfix/WIFI-851: Added prevFirmwareVersionRecordId to Update Assignment

### DIFF
--- a/src/containers/Firmware/components/AssignmentModal/index.js
+++ b/src/containers/Firmware/components/AssignmentModal/index.js
@@ -90,7 +90,7 @@ const AssignmentModal = ({
         ]}
       >
         {firmwareVersionLoading ? (
-          <Spin data-testid="firmwareVersionLoading" daclassName={styles.spinner} size="large" />
+          <Spin data-testid="firmwareVersionLoading" className={styles.spinner} size="large" />
         ) : (
           <Select
             className={globalStyles.field}

--- a/src/containers/Firmware/index.js
+++ b/src/containers/Firmware/index.js
@@ -53,8 +53,7 @@ const Firmware = ({
   };
 
   const createUpdateAssignment = ({ firmwareVersionRecordId, modelId }) => {
-    const { createdTimestamp, lastModifiedTimestamp } = traskAssignmentValues;
-    const prevFirmwareVersionRecordId = traskAssignmentValues.firmwareVersionRecordId;
+    const { createdTimestamp, lastModifiedTimestamp, firmwareVersionRecordId: prevFirmwareVersionRecordId } = traskAssignmentValues;
 
     onUpdateTrackAssignment(
       firmwareVersionRecordId,

--- a/src/containers/Firmware/index.js
+++ b/src/containers/Firmware/index.js
@@ -54,12 +54,7 @@ const Firmware = ({
 
   const createUpdateAssignment = ({ firmwareVersionRecordId, modelId }) => {
     const { createdTimestamp, lastModifiedTimestamp } = traskAssignmentValues;
-    let prevFirmwareVersionRecordId = firmwareVersionRecordId;
-    trackAssignmentData.forEach((element, index) => {
-      if (element.modelId === modelId) {
-        prevFirmwareVersionRecordId = trackAssignmentData[index].firmwareVersionRecordId;
-      }
-    });
+    const prevFirmwareVersionRecordId = traskAssignmentValues.firmwareVersionRecordId;
 
     onUpdateTrackAssignment(
       firmwareVersionRecordId,

--- a/src/containers/Firmware/index.js
+++ b/src/containers/Firmware/index.js
@@ -54,11 +54,19 @@ const Firmware = ({
 
   const createUpdateAssignment = ({ firmwareVersionRecordId, modelId }) => {
     const { createdTimestamp, lastModifiedTimestamp } = traskAssignmentValues;
+    let prevFirmwareVersionRecordId = firmwareVersionRecordId;
+    trackAssignmentData.forEach((element, index) => {
+      if (element.modelId === modelId) {
+        prevFirmwareVersionRecordId = trackAssignmentData[index].firmwareVersionRecordId;
+      }
+    });
+
     onUpdateTrackAssignment(
       firmwareVersionRecordId,
       modelId,
       createdTimestamp,
-      lastModifiedTimestamp
+      lastModifiedTimestamp,
+      prevFirmwareVersionRecordId
     );
     setEditAssignmentModal(false);
   };


### PR DESCRIPTION
JIRA: [WIFI-851](https://telecominfraproject.atlassian.net/browse/WIFI-851)

## Description
*Summary of this PR*
- added `prevFirmwareVersionRecordId` to be found and passed down to `onUpdateTrackAssignment` in the `createUpdateAssignment` function
- this PR is linked with [WIFI-851 of wlan-cloud-ui PR](https://github.com/Telecominfraproject/wlan-cloud-ui/pull/61)

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/70719869/95374425-4df17900-08ac-11eb-8554-e8947119fbeb.png)


### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/70719869/95374448-547ff080-08ac-11eb-84af-678a07fac8cd.png)
