### PR TITLE
hotfix/WIFI-904: Added padding to Back Button

### DIFF
--- a/src/containers/AccessPointDetails/index.js
+++ b/src/containers/AccessPointDetails/index.js
@@ -5,6 +5,7 @@ import { Card, Breadcrumb } from 'antd';
 import { WifiOutlined, LeftOutlined } from '@ant-design/icons';
 
 import Button from 'components/Button';
+import Header from 'components/Header';
 import Modal from 'components/Modal';
 import { getLocationPath } from 'utils/locations';
 
@@ -110,10 +111,11 @@ const AccessPointDetails = ({
         content={<p>Please confirm exiting without saving this Access Point page.</p>}
         mask={false}
       />
-
-      <Button icon={<LeftOutlined />} onClick={() => handlePageChange('/network/access-points')}>
-        BACK
-      </Button>
+      <Header>
+        <Button icon={<LeftOutlined />} onClick={() => handlePageChange('/network/access-points')}>
+          BACK
+        </Button>
+      </Header>
       <Card
         title={
           <div className={styles.InlineBlockDiv}>


### PR DESCRIPTION
JIRA: [WIFI-904](https://telecominfraproject.atlassian.net/browse/WIFI-904)

## Description
*Summary of this PR*
- Made the `BACK` button a Header similar to the other tables

### Before this PR
*Screenshots of what it looked like before this PR*
<img width="1792" alt="Screen Shot 2020-10-08 at 11 45 02 AM" src="https://user-images.githubusercontent.com/70719869/95482185-d5e28c00-095b-11eb-9974-49e7cb24b881.png">


### After this PR
*Screenshots of what it will look like after this PR*
<img width="1792" alt="Screen Shot 2020-10-08 at 11 43 33 AM" src="https://user-images.githubusercontent.com/70719869/95482141-cbc08d80-095b-11eb-816b-25f11db5ed47.png">
