### PR TITLE
hotfix/WIFI-965: Sorted radio columns under advanced

### DIFF
--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -184,10 +184,16 @@ const General = ({
     return val;
   };
 
+  const sortRadio = obj => {
+    const sortOrder = ['is2dot4GHz', 'is5GHz', 'is5GHzU', 'is5GHzL'];
+
+    return obj.sort((a, b) => sortOrder.indexOf(a) - sortOrder.indexOf(b));
+  };
+
   const renderItem = (label, obj = {}, dataIndex, renderInput, options = {}) => (
     <Item label={label} colon={false}>
       <div className={styles.InlineDiv}>
-        {Object.keys(obj).map(i =>
+        {sortRadio(Object.keys(obj)).map(i =>
           renderInput ? (
             renderInput(obj, dataIndex, i, label, options)
           ) : (


### PR DESCRIPTION
JIRA: [WIFI-965](https://telecominfraproject.atlassian.net/secure/RapidBoard.jspa?rapidView=40&projectKey=WIFI&modal=detail&selectedIssue=WIFI-965&assignee=5f93042addb0df006e8f3fed)

## Description
*Summary of this PR*
Put the radio types in sorted order in the advanced network settings.

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/73356579/97193080-f9407000-177e-11eb-9814-5217d67300c4.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/73356579/97192804-aa92d600-177e-11eb-859c-c239d5ae390c.png)

