### PR TITLE
hotfix/WIFI-964: Fixed alignment of Radio Columns on AP Status page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tip-wlan/wlan-cloud-ui-library",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -6,9 +6,9 @@ import _ from 'lodash';
 
 import Loading from 'components/Loading';
 import Button from 'components/Button';
-import styles from '../../index.module.scss';
+import { sortRadioTypes } from 'utils/sortRadioTypes';
 
-import { sortRadios } from '../../../../utils/sortRadios';
+import styles from '../../index.module.scss';
 
 const { Item } = Form;
 const { Option } = Select;
@@ -189,7 +189,7 @@ const General = ({
   const renderItem = (label, obj = {}, dataIndex, renderInput, options = {}) => (
     <Item label={label} colon={false}>
       <div className={styles.InlineDiv}>
-        {sortRadios(Object.keys(obj)).map(i =>
+        {sortRadioTypes(Object.keys(obj)).map(i =>
           renderInput ? (
             renderInput(obj, dataIndex, i, label, options)
           ) : (

--- a/src/containers/AccessPointDetails/components/Status/index.js
+++ b/src/containers/AccessPointDetails/components/Status/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { Card, Form, Table } from 'antd';
 import PropTypes from 'prop-types';
 
+import { sortRadioTypes } from 'utils/sortRadioTypes';
+
 import styles from '../../index.module.scss';
 
 const { Item } = Form;
@@ -14,7 +16,7 @@ const Status = ({ data }) => {
 
   const columns = [
     {
-      title: 'Severity	',
+      title: 'Severity',
       dataIndex: 'severity',
       key: 'severity',
     },
@@ -24,7 +26,7 @@ const Status = ({ data }) => {
       key: 'type',
     },
     {
-      title: 'Message	',
+      title: 'Message',
       dataIndex: ['details', 'message'],
       key: 'security',
     },
@@ -42,12 +44,25 @@ const Status = ({ data }) => {
   const renderSpanItem = (label, obj, dataIndex) => (
     <Item label={label} colon={false}>
       <div className={styles.InlineDiv}>
-        {obj &&
-          Object.keys(obj).map(i => (
+        {obj ? (
+          sortRadioTypes(Object.keys(data?.details?.radioMap)).map(i => (
             <span key={i} className={styles.spanStyle}>
-              {dataIndex ? obj[i][dataIndex] : obj[i]}
+              {dataIndex ? (
+                <>{!obj[i] ? 'N/A' : <>{obj[i][dataIndex] ? obj[i][dataIndex] : 'N/A'}</>}</>
+              ) : (
+                <>{!obj[i] ? 'N/A' : obj[i]}</>
+              )}
             </span>
-          ))}
+          ))
+        ) : (
+          <>
+            {Object.keys(data?.details?.radioMap).map(i => (
+              <span className={styles.spanStyle} key={i}>
+                N/A
+              </span>
+            ))}
+          </>
+        )}
       </div>
     </Item>
   );
@@ -56,33 +71,22 @@ const Status = ({ data }) => {
     <>
       <Form {...layout}>
         <Card title="Status">
-          {renderSpanItem(' ', data.details && data.details.radioMap, 'radioType')}
+          {renderSpanItem(' ', data?.details?.radioMap, 'radioType')}
 
-          {renderSpanItem('Channel', data.details && data.details.radioMap, 'channelNumber')}
+          {renderSpanItem('Channel', data?.details?.radioMap, 'channelNumber')}
 
           {renderSpanItem(
             'Noise Floor',
-            data.status &&
-              data.status.radioUtilization &&
-              data.status.radioUtilization.detailsJSON &&
-              data.status.radioUtilization.detailsJSON.avgNoiseFloor
+            data?.status?.radioUtilization?.detailsJSON?.avgNoiseFloor
           )}
-
           {renderSpanItem(
             'Number of Devices',
-            data.status &&
-              data.status.clientDetails &&
-              data.status.clientDetails.detailsJSON &&
-              data.status.clientDetails.detailsJSON.numClientsPerRadio,
+            data?.status?.clientDetails?.detailsJSON?.numClientsPerRadio,
             'radioType'
           )}
-
           {renderSpanItem(
             'Available Capacity',
-            data.status &&
-              data.status.radioUtilization &&
-              data.status.radioUtilization.detailsJSON &&
-              data.status.radioUtilization.detailsJSON.capacityDetails,
+            data?.status?.radioUtilization?.detailsJSON?.capacityDetails,
             'availableCapacity'
           )}
         </Card>

--- a/src/containers/AccessPointDetails/components/Status/index.js
+++ b/src/containers/AccessPointDetails/components/Status/index.js
@@ -48,9 +48,9 @@ const Status = ({ data }) => {
           sortRadioTypes(Object.keys(data?.details?.radioMap)).map(i => (
             <span key={i} className={styles.spanStyle}>
               {dataIndex ? (
-                <>{!obj[i] ? 'N/A' : <>{obj[i][dataIndex] ? obj[i][dataIndex] : 'N/A'}</>}</>
+                <>{obj[i][dataIndex] ? obj[i][dataIndex] : 'N/A'}</>
               ) : (
-                <>{!obj[i] ? 'N/A' : obj[i]}</>
+                <>{obj[i] ? obj[i] : 'N/A'}</>
               )}
             </span>
           ))

--- a/src/containers/AccessPointDetails/components/Status/index.js
+++ b/src/containers/AccessPointDetails/components/Status/index.js
@@ -44,21 +44,11 @@ const Status = ({ data }) => {
   const renderSpanItem = (label, obj, dataIndex) => (
     <Item label={label} colon={false}>
       <div className={styles.InlineDiv}>
-        {obj ? (
-          sortRadioTypes(Object.keys(data?.details?.radioMap)).map(i => (
-            <span key={i} className={styles.spanStyle}>
-              {dataIndex ? obj[i]?.[dataIndex] || 'N/A' : obj[i] || 'N/A'}
-            </span>
-          ))
-        ) : (
-          <>
-            {Object.keys(data?.details?.radioMap).map(i => (
-              <span className={styles.spanStyle} key={i}>
-                N/A
-              </span>
-            ))}
-          </>
-        )}
+        {sortRadioTypes(Object.keys(data?.details?.radioMap)).map(i => (
+          <span key={i} className={styles.spanStyle}>
+            {dataIndex ? obj?.[i]?.[dataIndex] || 'N/A' : obj[i] || 'N/A'}
+          </span>
+        ))}
       </div>
     </Item>
   );

--- a/src/containers/AccessPointDetails/components/Status/index.js
+++ b/src/containers/AccessPointDetails/components/Status/index.js
@@ -47,11 +47,7 @@ const Status = ({ data }) => {
         {obj ? (
           sortRadioTypes(Object.keys(data?.details?.radioMap)).map(i => (
             <span key={i} className={styles.spanStyle}>
-              {dataIndex ? (
-                <>{obj[i][dataIndex] ? obj[i][dataIndex] : 'N/A'}</>
-              ) : (
-                <>{obj[i] ? obj[i] : 'N/A'}</>
-              )}
+              {dataIndex ? obj[i]?.[dataIndex] || 'N/A' : obj[i] || 'N/A'}
             </span>
           ))
         ) : (

--- a/src/containers/AccessPointDetails/components/Status/index.js
+++ b/src/containers/AccessPointDetails/components/Status/index.js
@@ -46,7 +46,7 @@ const Status = ({ data }) => {
       <div className={styles.InlineDiv}>
         {sortRadioTypes(Object.keys(data?.details?.radioMap)).map(i => (
           <span key={i} className={styles.spanStyle}>
-            {dataIndex ? obj?.[i]?.[dataIndex] || 'N/A' : obj[i] || 'N/A'}
+            {(dataIndex ? obj?.[i]?.[dataIndex] : obj?.[i]) || 'N/A'}
           </span>
         ))}
       </div>

--- a/src/utils/sortRadioTypes.js
+++ b/src/utils/sortRadioTypes.js
@@ -1,0 +1,5 @@
+export const sortRadioTypes = obj => {
+  const sortOrder = ['is2dot4GHz', 'is5GHz', 'is5GHzU', 'is5GHzL'];
+
+  return obj.sort((a, b) => sortOrder.indexOf(a) - sortOrder.indexOf(b));
+};

--- a/src/utils/sortRadios.js
+++ b/src/utils/sortRadios.js
@@ -1,5 +1,0 @@
-export const sortRadios = obj => {
-  const sortOrder = ['is2dot4GHz', 'is5GHz', 'is5GHzU', 'is5GHzL'];
-
-  return obj.sort((a, b) => sortOrder.indexOf(a) - sortOrder.indexOf(b));
-};


### PR DESCRIPTION
JIRA: [WIFI-964](https://telecominfraproject.atlassian.net/secure/RapidBoard.jspa?rapidView=40&projectKey=WIFI&modal=detail&selectedIssue=WIFI-964&assignee=5f93042addb0df006e8f3fed)

## Description
*Summary of this PR*
Fixed the alignment of Radio Columns on AP Status Page when values are missing. Used a grid layout instead of a flex layout. 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/73356579/97201371-c0a59400-1788-11eb-8a79-7fd85f9f757c.png)

### After this PR
*Screenshots of what it will look like after this PR*
![Screen Shot 2020-10-27 at 4 24 37 PM](https://user-images.githubusercontent.com/73356579/97359864-d17f0400-1873-11eb-963d-a47ce3bec851.png)

