### PR TITLE
hotfix/WIFI-789: fixed highlighting issue for safari browsers

### DIFF
--- a/src/containers/Dashboard/components/LineChart/index.js
+++ b/src/containers/Dashboard/components/LineChart/index.js
@@ -45,7 +45,7 @@ const LineChart = ({ title, data, options }) => {
           }}
           colors={COLORS}
         >
-          <Chart type="spline" zoomType="x" backgroundColor="#141414" />
+          <Chart type="spline" zoomType="x" backgroundColor="#141414" className={styles.noSelect} />
           <XAxis
             tickPixelInterval={90}
             dateTimeLabelFormats={dateTimeLabelFormats}

--- a/src/containers/Dashboard/components/LineChart/index.module.scss
+++ b/src/containers/Dashboard/components/LineChart/index.module.scss
@@ -17,4 +17,8 @@
 .noSelect {
   -webkit-touch-callout: none; // iOS Safari 
   -webkit-user-select: none; // Safari 
+  -khtml-user-select: none; // Konqueror HTML 
+  -moz-user-select: none; // Old versions of Firefox
+  -ms-user-select: none; // Internet Explorer & Edge 
+  user-select: none; // Chrome, Edge, Opera and Firefox
 }

--- a/src/containers/Dashboard/components/LineChart/index.module.scss
+++ b/src/containers/Dashboard/components/LineChart/index.module.scss
@@ -13,3 +13,8 @@
 :global(.highcharts-button-box) {
   fill: #141414;
 }
+
+.noSelect {
+  -webkit-touch-callout: none; // iOS Safari 
+  -webkit-user-select: none; // Safari 
+}


### PR DESCRIPTION
JIRA: [WIFI-789](https://telecominfraproject.atlassian.net/browse/WIFI-789)

## Description
*Summary of this PR*
- on dashboard when zooming in on line graphs surrounding graph text gets highlighted
- issue only occurs on safari browsers

solution
- make surrounding line graph text un-selectable specifically for safari browsers 

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*