### PR TITLE
hotfix/WIFI-1020: Set values to Ethernet Mac Addr and Manufacturer in AP Details page under Identity card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tip-wlan/wlan-cloud-ui-library",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -292,8 +292,8 @@ const General = ({
         <Item label="Serial Number">{data.serial} </Item>
         <Item label="SKU"> {data.status.protocol.reportedSku}</Item>
         <Item label="Country Code"> {data.status.protocol.countryCode}</Item>
-        <Item label="Ethernet MAC Address"> {data.status.protocol.reportedMacAddr}</Item>
-        <Item label="Manufacturer"> {data.status.protocol.manufacturer}</Item>
+        <Item label="Ethernet MAC Address"> {data.status.protocol.details.reportedMacAddr}</Item>
+        <Item label="Manufacturer"> {data.status.protocol.details.manufacturer}</Item>
         <Item label="Asset ID"> {data.inventoryId}</Item>
       </Card>
 


### PR DESCRIPTION
JIRA: [WIFI-1020](https://telecominfraproject.atlassian.net/secure/RapidBoard.jspa?rapidView=40&modal=detail&selectedIssue=WIFI-1020&assignee=5f93042addb0df006e8f3fed)

## Description
*Summary of this PR*
Set values of 'Ethernet MAC address' and 'Manufacturer' in Access Point details page under the Identity card. 

### Before this PR
*Screenshots of what it looked like before this PR*
![Screen Shot 2020-11-02 at 2 16 00 PM](https://user-images.githubusercontent.com/73356579/97910075-31aff300-1d17-11eb-9ea2-98ff7f116d30.png)


### After this PR
*Screenshots of what it will look like after this PR*
![Screen Shot 2020-11-02 at 2 16 50 PM](https://user-images.githubusercontent.com/73356579/97910090-37a5d400-1d17-11eb-8e6e-acfccb36f2a2.png)
