### PR TITLE
hotfix/WIFI-1021: AP Details page Status tab shows client devices

### DIFF
--- a/src/containers/AccessPointDetails/components/Status/index.js
+++ b/src/containers/AccessPointDetails/components/Status/index.js
@@ -58,17 +58,14 @@ const Status = ({ data }) => {
       <Form {...layout}>
         <Card title="Status">
           {renderSpanItem(' ', data?.details?.radioMap, 'radioType')}
-
           {renderSpanItem('Channel', data?.details?.radioMap, 'channelNumber')}
-
           {renderSpanItem(
             'Noise Floor',
             data?.status?.radioUtilization?.detailsJSON?.avgNoiseFloor
           )}
           {renderSpanItem(
             'Number of Devices',
-            data?.status?.clientDetails?.detailsJSON?.numClientsPerRadio,
-            'radioType'
+            data?.status?.clientDetails?.detailsJSON?.numClientsPerRadio
           )}
           {renderSpanItem(
             'Available Capacity',


### PR DESCRIPTION
JIRA: [WIFI-1021](https://telecominfraproject.atlassian.net/jira/software/c/projects/WIFI/issues/WIFI-1021?jql=project%20%3D%20%22WIFI%22%20AND%20assignee%20IN%20%28currentUser%28%29%29%20ORDER%20BY%20created%20DESC)

## Description
*Summary of this PR*
Status tab in AP details page shows client devices. 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/73356579/98268247-4af4b180-1f5a-11eb-9898-d18817fc6273.png)


### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/73356579/98268405-79728c80-1f5a-11eb-9b4e-a6a3af767620.png)
