### PR TITLE
hotfix/WIFI-1055: added min values to linechart

### DIFF
--- a/src/containers/Dashboard/components/LineChart/index.js
+++ b/src/containers/Dashboard/components/LineChart/index.js
@@ -69,6 +69,8 @@ const LineChart = ({ title, data, options }) => {
             labels={{
               formatter: options.formatter ? options.formatter : null,
             }}
+            min={0}
+            minTickInterval={1}
           >
             {Array.isArray(data?.value) ? (
               <SplineSeries key={data.key} name={data.key} data={data.value} />


### PR DESCRIPTION
JIRA: [WIFI-1055](https://telecominfraproject.atlassian.net/secure/RapidBoard.jspa?rapidView=40&projectKey=WIFI&modal=detail&selectedIssue=WIFI-1055&assignee=5f93042addb0df006e8f3fed)

## Description
*Summary of this PR*
added default values for the linecharts y-axis. 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/73356579/98572745-f9169900-2283-11eb-9294-f16e3ddaa487.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/73356579/98572776-02076a80-2284-11eb-8fe4-4bbf1bcb751a.png)