### PR TITLE
hotfix/NETEXP-649: disabled Bonjour Gateway option

### DIFF
--- a/src/containers/AddProfile/index.js
+++ b/src/containers/AddProfile/index.js
@@ -173,7 +173,7 @@ const AddProfile = ({
               >
                 <Option value="ssid">SSID</Option>
                 <Option value="equipment_ap">Access Point</Option>
-                <Option value="bonjour">Bonjour Gateway</Option>
+                <Option value="bonjour" disabled>Bonjour Gateway</Option>
                 <Option value="captive_portal">Captive Portal</Option>
                 <Option value="radius">Radius</Option>
                 <Option value="rf">RF</Option>


### PR DESCRIPTION
JIRA: [NETEXP-649](https://connectustechnologies.atlassian.net/browse/NETEXP-649)

## Description
*Summary of this PR*
- disabled Bonjour Gateway option in Add Profile page
- temporary until this is implemented

### Before this PR
*Screenshots of what it looked like before this PR*
<img width="1792" alt="Screen Shot 2020-12-08 at 5 02 01 PM" src="https://user-images.githubusercontent.com/70719869/101546919-81698600-3977-11eb-8628-e1b0fab75288.png">


### After this PR
*Screenshots of what it will look like after this PR*
<img width="1792" alt="Screen Shot 2020-12-08 at 5 01 02 PM" src="https://user-images.githubusercontent.com/70719869/101546909-7d3d6880-3977-11eb-8eee-11a39c6ea339.png">
