### PR TITLE
bugfix/NETEXP-741: fix being able to deleting current user

### DIFF
--- a/src/containers/Accounts/index.js
+++ b/src/containers/Accounts/index.js
@@ -12,7 +12,7 @@ import FormModal from './components/FormModal';
 
 const Accounts = ({
   data,
-  userId,
+  currentUserId,
   onCreateUser,
   onEditUser,
   onDeleteUser,
@@ -91,7 +91,7 @@ const Accounts = ({
       key: 'delete',
       width: 64,
       render: (_, record) =>
-        userId.toString() !== record.id && (
+        currentUserId.toString() !== record.id && (
           <Button
             title="delete"
             className={styles.InfoButton}
@@ -164,14 +164,14 @@ Accounts.propTypes = {
   data: PropTypes.instanceOf(Array),
   onLoadMore: PropTypes.func,
   isLastPage: PropTypes.bool,
-  userId: PropTypes.number,
+  currentUserId: PropTypes.number,
 };
 
 Accounts.defaultProps = {
   data: [],
   onLoadMore: () => {},
   isLastPage: true,
-  userId: null,
+  currentUserId: null,
 };
 
 export default Accounts;

--- a/src/containers/Accounts/index.js
+++ b/src/containers/Accounts/index.js
@@ -91,7 +91,7 @@ const Accounts = ({
       key: 'delete',
       width: 64,
       render: (_, record) =>
-        currentUserId.toString() !== record.id && (
+        currentUserId?.toString() !== record.id && (
           <Button
             title="delete"
             className={styles.InfoButton}

--- a/src/containers/Accounts/index.js
+++ b/src/containers/Accounts/index.js
@@ -10,7 +10,15 @@ import Modal from 'components/Modal';
 import styles from './index.module.scss';
 import FormModal from './components/FormModal';
 
-const Accounts = ({ data, onCreateUser, onEditUser, onDeleteUser, onLoadMore, isLastPage }) => {
+const Accounts = ({
+  data,
+  currentUser,
+  onCreateUser,
+  onEditUser,
+  onDeleteUser,
+  onLoadMore,
+  isLastPage,
+}) => {
   const [deleteModal, setDeleteModal] = useState(false);
   const [editModal, setEditModal] = useState(false);
   const [addModal, setAddModal] = useState(false);
@@ -82,24 +90,27 @@ const Accounts = ({ data, onCreateUser, onEditUser, onDeleteUser, onLoadMore, is
       dataIndex: 'delete',
       key: 'delete',
       width: 64,
-      render: (_, record) => (
-        <Button
-          title="delete"
-          className={styles.InfoButton}
-          type="primary"
-          icon={<DeleteFilled />}
-          onClick={() => {
-            setDeleteModal(true);
-            setActiveUser({
-              id: record.id,
-              email: record.email,
-              roles: record.roles,
-              customerId: record.customerId,
-              lastModifiedTimestamp: record.lastModifiedTimestamp,
-            });
-          }}
-        />
-      ),
+      render: (_, record) =>
+        currentUser?.id === record.id ? (
+          <></>
+        ) : (
+          <Button
+            title="delete"
+            className={styles.InfoButton}
+            type="primary"
+            icon={<DeleteFilled />}
+            onClick={() => {
+              setDeleteModal(true);
+              setActiveUser({
+                id: record.id,
+                email: record.email,
+                roles: record.roles,
+                customerId: record.customerId,
+                lastModifiedTimestamp: record.lastModifiedTimestamp,
+              });
+            }}
+          />
+        ),
     },
   ];
 
@@ -155,12 +166,14 @@ Accounts.propTypes = {
   data: PropTypes.instanceOf(Array),
   onLoadMore: PropTypes.func,
   isLastPage: PropTypes.bool,
+  currentUser: PropTypes.shape({}),
 };
 
 Accounts.defaultProps = {
   data: [],
   onLoadMore: () => {},
   isLastPage: true,
+  currentUser: {},
 };
 
 export default Accounts;

--- a/src/containers/Accounts/index.js
+++ b/src/containers/Accounts/index.js
@@ -12,7 +12,7 @@ import FormModal from './components/FormModal';
 
 const Accounts = ({
   data,
-  currentUser,
+  userId,
   onCreateUser,
   onEditUser,
   onDeleteUser,
@@ -91,9 +91,7 @@ const Accounts = ({
       key: 'delete',
       width: 64,
       render: (_, record) =>
-        currentUser?.id === record.id ? (
-          <></>
-        ) : (
+        userId.toString() !== record.id && (
           <Button
             title="delete"
             className={styles.InfoButton}
@@ -166,14 +164,14 @@ Accounts.propTypes = {
   data: PropTypes.instanceOf(Array),
   onLoadMore: PropTypes.func,
   isLastPage: PropTypes.bool,
-  currentUser: PropTypes.shape({}),
+  userId: PropTypes.number,
 };
 
 Accounts.defaultProps = {
   data: [],
   onLoadMore: () => {},
   isLastPage: true,
-  currentUser: {},
+  userId: null,
 };
 
 export default Accounts;

--- a/src/containers/Accounts/tests/index.test.js
+++ b/src/containers/Accounts/tests/index.test.js
@@ -25,10 +25,13 @@ const mockProps = {
   onDeleteUser: () => {},
   data: [
     {
+      customerId: "2",
+      id: "20",
       email: 'support@mail.com',
       roles: ['SuperUser'],
     },
   ],
+  currentUserId: 1,
 };
 
 const MISSING_EMAIL = 'Please input your e-mail';


### PR DESCRIPTION
JIRA: [NETEXP-741](https://connectustechnologies.atlassian.net/browse/NETEXP-741)

## Description
*Summary of this PR*
- part of other PR on CMAP side [NETEXP-741](https://bitbucket.org/connectustechnologies/cmap-ui/pull-requests/28/bugfix-netexp-741-pass-down-getuser-data)

- stops rendering of delete button on Users page only for the current user.

### Before this PR
*Screenshots of what it looked like before this PR*
<img width="1792" alt="Screen Shot 2020-12-12 at 3 39 42 PM" src="https://user-images.githubusercontent.com/70719869/101994418-49708480-3c90-11eb-8ebe-306d6abab8c8.png">


### After this PR
*Screenshots of what it will look like after this PR*
<img width="1792" alt="Screen Shot 2020-12-12 at 3 33 10 PM" src="https://user-images.githubusercontent.com/70719869/101994411-38c00e80-3c90-11eb-8431-5c062512f361.png">
