### PR TITLE
hotfix/legendColor: Changed dashboard legend & hover colour

### DIFF
--- a/src/containers/Dashboard/components/LineChart/index.js
+++ b/src/containers/Dashboard/components/LineChart/index.js
@@ -59,7 +59,10 @@ const LineChart = ({ title, data, options }) => {
             xDateFormat="%b %e %Y %l:%M%P"
             pointFormatter={options.tooltipFormatter ? options.tooltipFormatter : null}
           />
-          <Legend>
+          <Legend
+            itemStyle={{ color: 'rgba(255, 255, 255, 0.85)' }}
+            itemHoverStyle={{ color: 'rgba(255, 255, 255)' }}
+          >
             <Legend.Title />
           </Legend>
           <YAxis


### PR DESCRIPTION
JIRA: [ID](LINK)

## Description
*Summary of this PR*
- changed legend colour and legend hover colour to be consistent with rest of page

### Before this PR
*Screenshots of what it looked like before this PR*
<img width="1790" alt="Screen Shot 2020-12-18 at 12 33 32 PM" src="https://user-images.githubusercontent.com/70719869/102643536-6ba15100-412d-11eb-80ee-a0f35d52f671.png">
<img width="1790" alt="Screen Shot 2020-12-18 at 12 33 34 PM" src="https://user-images.githubusercontent.com/70719869/102643548-6fcd6e80-412d-11eb-9cc8-e5c2d648ab33.png">


### After this PR
*Screenshots of what it will look like after this PR*
<img width="1790" alt="Screen Shot 2020-12-18 at 12 32 42 PM" src="https://user-images.githubusercontent.com/70719869/102643558-7360f580-412d-11eb-9f74-6cdd00e609a8.png">
<img width="1790" alt="Screen Shot 2020-12-18 at 12 32 48 PM" src="https://user-images.githubusercontent.com/70719869/102643578-79ef6d00-412d-11eb-90db-663f7b55c18f.png">
