### PR TITLE
fixed AP from resetting when SSID selected

### DIFF
--- a/src/containers/ProfileDetails/components/AccessPoint/index.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/index.js
@@ -70,9 +70,14 @@ const AccessPointForm = ({
       syntheticClientEnabled: details?.syntheticClientEnabled ? 'true' : 'false',
       equipmentDiscovery: details?.equipmentDiscovery ? 'true' : 'false',
       rfProfileId: currentRfId,
+    });
+  }, [form, details]);
+
+  useEffect(() => {
+    form.setFieldsValue({
       childProfileIds: selectedChildProfiles.map(i => i.id),
     });
-  }, [form, details, selectedChildProfiles]);
+  }, [selectedChildProfiles]);
 
   const columns = [
     {


### PR DESCRIPTION
JIRA: [NETEXP-841](https://connectustechnologies.atlassian.net/browse/NETEXP-841)

## Description
*Summary of this PR*
- When selecting a SSID profile the entire form is reset to what was initially, for `addProfile` previous values are the default values

SOLUTION:
- separated `childProfileIds` to it's own `form.setFieldsValue` to not impact rest of form when SSID's are added to the list

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*