### PR TITLE
bugfix/NETEXP-930: Color inconsistencies on OS highchart graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tip-wlan/wlan-cloud-ui-library",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
+++ b/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
@@ -11,7 +11,7 @@ import {
   SplineSeries,
   Tooltip,
 } from 'react-jsx-highstock';
-import { formatBytes } from 'utils/bytes';
+import { formatBytes, labelFormatter } from 'utils/bytes';
 
 import Loading from 'components/Loading';
 
@@ -101,6 +101,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
             id={`cpuCore${i}`}
             name={`CPU Core ${i}`}
             data={cpuUsage[i]}
+            color="#7cb5ec"
           />
         ))}
       </YAxis>
@@ -109,6 +110,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
         id="free"
         labels={{
           style: { color: '#34AE29' },
+          formatter: labelFormatter,
         }}
         opposite
         visible={visible}
@@ -120,7 +122,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
         >
           Free Memory (MB)
         </YAxis.Title>
-        <SplineSeries id="freeMemory" name="Free Memory" data={freeMemory} />
+        <SplineSeries id="freeMemory" name="Free Memory" data={freeMemory} color="#34AE29" />
       </YAxis>
 
       <YAxis
@@ -137,7 +139,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
         >
           CPU Temperature (°C)
         </YAxis.Title>
-        <SplineSeries id="cpuTemp" name="CPU Temperature" data={cpuTemp} />
+        <SplineSeries id="cpuTemp" name="CPU Temperature" data={cpuTemp} color="#f7a35c" />
       </YAxis>
     </HighchartsStockChart>
   );

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -13,6 +13,10 @@ export function formatBytes(bytes, decimals = 2) {
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
 }
 
+export function labelFormatter() {
+  return formatBytes(this.value).replace(/[^\d.-]/g, '');
+}
+
 export function formatBitsPerSecond(bps) {
   if (bps >= 1000000000) {
     return `${_.round(bps / 1000000000, 0)} Gbps`;


### PR DESCRIPTION
JIRA: [NETEXP-930](https://connectustechnologies.atlassian.net/browse/NETEXP-930)

## Description
*Summary of this PR*
Fixed color inconsistencies on the highchart graph on the OS page. 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/104512578-6a443680-55bc-11eb-9b37-2fd88ad10bda.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/104512445-38cb6b00-55bc-11eb-925d-c0f69123bc65.png)
