### PR TITLE
bugfix/NETEXP-947: RF Profile Radio modes

### DIFF
--- a/src/containers/ProfileDetails/components/RF/index.js
+++ b/src/containers/ProfileDetails/components/RF/index.js
@@ -107,7 +107,7 @@ const RFForm = ({ form, details }) => {
   const renderItem = (label, dataIndex, renderInput, options = {}) => (
     <Item label={label} colon={false}>
       <div className={styles.InlineDiv}>
-        {Object.keys(details.rfConfigMap).map(i => renderInput(dataIndex, i, label, options))}
+        {currentRadios.map(i => renderInput(dataIndex, i, label, options))}
       </div>
     </Item>
   );
@@ -188,18 +188,20 @@ const RFForm = ({ form, details }) => {
           },
         })}
         {renderItem('Radio Mode', ['radioMode'], renderOptionItem, {
-          dropdown: (
-            <Select className={styles.Field}>
-              <Option value="modeN">N</Option>
-              <Option value="modeAC">AC</Option>
-              <Option value="modeGN">GN</Option>
-              <Option value="modeX">X</Option>
-              <Option value="modeA">A</Option>
-              <Option value="modeB">B</Option>
-              <Option value="modeG">G</Option>
-              <Option value="modeAB">AB</Option>
-            </Select>
-          ),
+          dropdown: key => {
+            return (
+              <Select className={styles.Field}>
+                <Option value="modeN">N</Option>
+                {key === 'is2dot4GHz' ? null : <Option value="modeAC">AC</Option>}
+                {key === 'is2dot4GHz' ? null : <Option value="modeGN">GN</Option>}
+                {key === 'is2dot4GHz' ? null : <Option value="modeX">X</Option>}
+                {key === 'is2dot4GHz' ? null : <Option value="modeA">A</Option>}
+                {key === 'is5GHz' ? null : <Option value="modeB">B</Option>}
+                {key === 'is5GHz' ? null : <Option value="modeG">G</Option>}
+                {key === 'is2dot4GHz' ? null : <Option value="modeAB">AB</Option>}
+              </Select>
+            );
+          },
         })}
         {renderItem(
           <span>Beacon Interval (milliseconds)</span>,

--- a/src/containers/ProfileDetails/components/RF/index.js
+++ b/src/containers/ProfileDetails/components/RF/index.js
@@ -196,6 +196,12 @@ const RFForm = ({ form, details }) => {
             return (
               <Select className={styles.Field}>
                 <Option value="modeN">N</Option>
+                {key !== 'is5GHz' && (
+                  <>
+                    <Option value="modeB">B</Option>
+                    <Option value="modeG">G</Option>
+                  </>
+                )}
                 {key !== 'is2dot4GHz' && (
                   <>
                     <Option value="modeAC">AC</Option>
@@ -203,12 +209,6 @@ const RFForm = ({ form, details }) => {
                     <Option value="modeX">X</Option>
                     <Option value="modeA">A</Option>
                     <Option value="modeAB">AB</Option>
-                  </>
-                )}
-                {key !== 'is5GHz' && (
-                  <>
-                    <Option value="modeB">B</Option>
-                    <Option value="modeG">G</Option>
                   </>
                 )}
               </Select>

--- a/src/containers/ProfileDetails/components/RF/index.js
+++ b/src/containers/ProfileDetails/components/RF/index.js
@@ -180,9 +180,13 @@ const RFForm = ({ form, details }) => {
             return (
               <Select className={styles.Field}>
                 <Option value="is20MHz">20MHz</Option>
-                {key === 'is2dot4GHz' ? null : <Option value="is40MHz">40MHz</Option>}
-                {key === 'is2dot4GHz' ? null : <Option value="is80MHz">80MHz</Option>}
-                {key === 'is2dot4GHz' ? null : <Option value="is160MHz">160MHz</Option>}
+                {key !== 'is2dot4GHz' && (
+                  <>
+                    <Option value="is40MHz">40MHz</Option>
+                    <Option value="is80MHz">80MHz</Option>
+                    <Option value="is160MHz">160MHz</Option>
+                  </>
+                )}
               </Select>
             );
           },
@@ -192,13 +196,21 @@ const RFForm = ({ form, details }) => {
             return (
               <Select className={styles.Field}>
                 <Option value="modeN">N</Option>
-                {key === 'is2dot4GHz' ? null : <Option value="modeAC">AC</Option>}
-                {key === 'is2dot4GHz' ? null : <Option value="modeGN">GN</Option>}
-                {key === 'is2dot4GHz' ? null : <Option value="modeX">X</Option>}
-                {key === 'is2dot4GHz' ? null : <Option value="modeA">A</Option>}
-                {key === 'is5GHz' ? null : <Option value="modeB">B</Option>}
-                {key === 'is5GHz' ? null : <Option value="modeG">G</Option>}
-                {key === 'is2dot4GHz' ? null : <Option value="modeAB">AB</Option>}
+                {key !== 'is2dot4GHz' && (
+                  <>
+                    <Option value="modeAC">AC</Option>
+                    <Option value="modeGN">GN</Option>
+                    <Option value="modeX">X</Option>
+                    <Option value="modeA">A</Option>
+                    <Option value="modeAB">AB</Option>
+                  </>
+                )}
+                {key !== 'is5GHz' && (
+                  <>
+                    <Option value="modeB">B</Option>
+                    <Option value="modeG">G</Option>
+                  </>
+                )}
               </Select>
             );
           },


### PR DESCRIPTION
JIRA: [NETEXP-947](https://connectustechnologies.atlassian.net/browse/NETEXP-947)

## Description
*Summary of this PR*
Fixed RF Profile radio modes so that 2.4GHZ setting has all modes with b / g / n and 5GHz has all modes except ones with b / g.
Also fixed the Channel Bandwidth constraint on the 2.4GHz band. 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/104651572-d343b100-5685-11eb-80e7-14a30e9172be.png)
![image](https://user-images.githubusercontent.com/55258316/104651603-dfc80980-5685-11eb-9df1-45725bc05c5a.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/104651438-a42d3f80-5685-11eb-8acb-e7028951fd07.png)
![image](https://user-images.githubusercontent.com/55258316/104651459-ae4f3e00-5685-11eb-9089-7fcf70de0c98.png)
