### PR TITLE
bugfix/NETEXP-996: OS stats labels and colors

### DIFF
--- a/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
+++ b/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
@@ -78,7 +78,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
         <XAxis.Title>Time</XAxis.Title>
       </XAxis>
 
-      <Legend>
+      <Legend itemStyle={{ color: '#fff' }}>
         <Legend.Title />
       </Legend>
       <YAxis
@@ -93,7 +93,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
             color: '#7cb5ec',
           }}
         >
-          CPU Usage (%)
+          CPU Utilization (%)
         </YAxis.Title>
         {Object.keys(cpuUsage).map(i => (
           <SplineSeries

--- a/src/containers/AccessPointDetails/components/OS/components/SolidGauge/index.js
+++ b/src/containers/AccessPointDetails/components/OS/components/SolidGauge/index.js
@@ -57,11 +57,20 @@ const SolidGauge = ({ data, title, label }) => {
         />
         <XAxis type="datetime" />
         <YAxis
-          stops={[
-            [0.1, '#55BF3B'],
-            [0.5, '#DDDF0D'],
-            [0.9, '#DF5353'],
-          ]}
+          stops={
+            title === 'Current Free Memory'
+              ? [
+                  [0.1, '#DF5353'],
+                  [0.1, '#FFFF00'],
+                  [0.25, '#FFFF00'],
+                  [0.25, '#55BF3B'],
+                ]
+              : [
+                  [0.1, '#55BF3B'],
+                  [0.5, '#FFFF00'],
+                  [0.9, '#DF5353'],
+                ]
+          }
           lineWidth={0}
           minorTickInterval={null}
           tickPixelInterval={400}

--- a/src/containers/AccessPointDetails/components/OS/index.js
+++ b/src/containers/AccessPointDetails/components/OS/index.js
@@ -86,7 +86,7 @@ const OS = ({ data, osData, handleRefresh }) => {
         showIcon
       />
       <div className={styles.InlineDiv} style={{ marginTop: '15px' }}>
-        <SolidGauge data={cpu} title="Current CPU" />
+        <SolidGauge data={cpu} title="Current CPU Utilization" />
         <SolidGauge data={memory} title="Current Free Memory" />
         <SolidGauge data={temperature} title="Current CPU Temp" label="°C" />
       </div>


### PR DESCRIPTION
JIRA: [NETEXP-996](https://connectustechnologies.atlassian.net/browse/NETEXP-996)

## Description
*Summary of this PR*
-change "Current CPU" to "Current CPU Utilization"
-change "CPU Usage" to "CPU Utilization" 
-On "Current Free Memory" make below 25% yellow and below 10% red
-change Legend font color to #fff

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/104947054-1739fd00-5989-11eb-9fa6-e9330c79260c.png)


### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/104946987-f5d91100-5988-11eb-88e6-5ed7b62ecc54.png)
