### PR TITLE
bugfix/NETEXP-999: fixed order of security and encryption modes

### DIFF
--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -295,18 +295,17 @@ const SSIDForm = ({
             onChange={value => setMode(value)}
             placeholder="Select Security and Encryption Mode"
           >
-            <Option value="open">Open (No Encryption)</Option>
-            <Option value="wpaPSK">WPA Personal</Option>
-            <Option value="wpaRadius">WPA Enterprise</Option>
-            <Option value="wpa2PSK">WPA & WPA2 Personal (mixed mode)</Option>
-            <Option value="wpa2Radius">WPA & WPA2 Enterprise (mixed mode)</Option>
-            <Option value="wpa2OnlyPSK">WPA2 Personal</Option>
-            <Option value="wpa2OnlyRadius">WPA2 Enterprise</Option>
-            <Option value="wep">WEP</Option>
             <Option value="wpa3OnlySAE">WPA3 Enterprise</Option>
             <Option value="wpa3MixedSAE">WPA3 Enterprise (mixed mode)</Option>
             <Option value="wpa3OnlyEAP">WPA3 Personal</Option>
             <Option value="wpa3MixedEAP">WPA3 Personal (mixed mode)</Option>
+            <Option value="wpa2OnlyRadius">WPA2 Enterprise</Option>
+            <Option value="wpa2Radius">WPA & WPA2 Enterprise (mixed mode)</Option>
+            <Option value="wpa2OnlyPSK">WPA2 Personal</Option>
+            <Option value="wpa2PSK">WPA & WPA2 Personal (mixed mode)</Option>
+            <Option value="wpaRadius">WPA Enterprise</Option>
+            <Option value="wep">WEP</Option>
+            <Option value="open">Open (No Encryption)</Option>
           </Select>
         </Item>
 
@@ -349,8 +348,7 @@ const SSIDForm = ({
           </Item>
         )}
 
-        {(mode === 'wpaPSK' ||
-          mode === 'wpa2PSK' ||
+        {(mode === 'wpa2PSK' ||
           mode === 'wpa2OnlyPSK' ||
           mode === 'wpa3OnlySAE' ||
           mode === 'wpa3MixedSAE') && (
@@ -494,8 +492,7 @@ const SSIDForm = ({
         </Item>
       </Card>
 
-      {mode !== 'wpaPSK' &&
-        mode !== 'wep' &&
+      {mode !== 'wep' &&
         mode !== 'wpa2PSK' &&
         mode !== 'wpa2OnlyPSK' &&
         mode !== 'wpa3MixedSAE' &&

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -303,7 +303,7 @@ const SSIDForm = ({
             <Option value="wpa2Radius">WPA & WPA2 Enterprise (mixed mode)</Option>
             <Option value="wpa2OnlyPSK">WPA2 Personal</Option>
             <Option value="wpa2PSK">WPA & WPA2 Personal (mixed mode)</Option>
-            <Option value="wpaRadius">WPA Enterprise</Option>
+            <Option value="wpaPSK">WPA Personal</Option>
             <Option value="wep">WEP</Option>
             <Option value="open">Open (No Encryption)</Option>
           </Select>
@@ -318,8 +318,7 @@ const SSIDForm = ({
           </Item>
         )}
 
-        {(mode === 'wpaRadius' ||
-          mode === 'wpa2Radius' ||
+        {(mode === 'wpa2Radius' ||
           mode === 'wpa2OnlyRadius' ||
           mode === 'wpa3OnlyEAP' ||
           mode === 'wpa3MixedEAP') && (
@@ -348,7 +347,8 @@ const SSIDForm = ({
           </Item>
         )}
 
-        {(mode === 'wpa2PSK' ||
+        {(mode === 'wpaPSK' ||
+          mode === 'wpa2PSK' ||
           mode === 'wpa2OnlyPSK' ||
           mode === 'wpa3OnlySAE' ||
           mode === 'wpa3MixedSAE') && (
@@ -492,7 +492,8 @@ const SSIDForm = ({
         </Item>
       </Card>
 
-      {mode !== 'wep' &&
+      {mode !== 'wpaPSK' &&
+        mode !== 'wep' &&
         mode !== 'wpa2PSK' &&
         mode !== 'wpa2OnlyPSK' &&
         mode !== 'wpa3MixedSAE' &&


### PR DESCRIPTION
JIRA: [NETEXP-999](https://connectustechnologies.atlassian.net/browse/NETEXP-999)

## Description
*Summary of this PR*
Changed order of security modes to:
wpa3-enterprise, 
wpa3Mixed-enterprise,
wpa3-personal,
wpa3mixed-personal, 
wpa2-enterprise, 
wpa2Mixed-enterprise, 
wpa2-personal, 
wpa2mixed-personal,
wpa-personal,
wep, open

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/104949625-42bee680-598d-11eb-8dda-9e5da6397427.png)
![image](https://user-images.githubusercontent.com/55258316/104949642-4a7e8b00-598d-11eb-8ec4-8cbd874115ff.png)


### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/104950671-1c01af80-598f-11eb-9fc0-76ce8ac5d875.png)
![image](https://user-images.githubusercontent.com/55258316/104950687-2328bd80-598f-11eb-8899-e04bcf036e22.png)
