### PR TITLE
changed initial secureMode value

### DIFF
--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -24,7 +24,7 @@ const SSIDForm = ({
   loadingRadiusProfiles,
 }) => {
   const { radioTypes } = useContext(ThemeContext);
-  const [mode, setMode] = useState(details.secureMode || 'open');
+  const [mode, setMode] = useState(details.secureMode || defaultSsidProfile.secureMode);
 
   const hexadecimalRegex = e => {
     const re = /[0-9A-F:]+/g;

--- a/src/containers/ProfileDetails/components/constants.js
+++ b/src/containers/ProfileDetails/components/constants.js
@@ -196,7 +196,7 @@ const defaultSsidProfile = {
   ssidAdminState: 'enabled',
   secureMode: 'wpa2OnlyPSK',
   vlanId: 1,
-  keyStr: 'w1r3l3ss-fr33d0m',
+  keyStr: '',
   broadcastSsid: 'enabled',
   keyRefresh: 0,
   noLocalSubnets: false,


### PR DESCRIPTION
JIRA: [NETEXP-948](https://connectustechnologies.atlassian.net/browse/NETEXP-948)

## Description
*Summary of this PR*

- Fixed bug where security key would not appear for the security mode WPA2 Personal. 
- Changed initial security key default value from "w1r3l3ss-fr33d0m" to null 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/106063947-098e2100-60c7-11eb-9f76-984d5ed25292.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/106064015-2296d200-60c7-11eb-800b-16c11036d99c.png)
