### PR TITLE
NETEXP-947: Updated radio modes on RF profiles

### DIFF
--- a/src/containers/ProfileDetails/components/RF/index.js
+++ b/src/containers/ProfileDetails/components/RF/index.js
@@ -196,7 +196,7 @@ const RFForm = ({ form, details }) => {
             return (
               <Select className={styles.Field}>
                 <Option value="modeN">N</Option>
-                {key !== 'is5GHz' && (
+                {key === 'is2dot4GHz' && (
                   <>
                     <Option value="modeB">B</Option>
                     <Option value="modeG">G</Option>
@@ -205,12 +205,10 @@ const RFForm = ({ form, details }) => {
                 {key !== 'is2dot4GHz' && (
                   <>
                     <Option value="modeAC">AC</Option>
-                    <Option value="modeGN">GN</Option>
-                    <Option value="modeX">X</Option>
                     <Option value="modeA">A</Option>
-                    <Option value="modeAB">AB</Option>
                   </>
                 )}
+                <Option value="modeAX">AX</Option>
               </Select>
             );
           },

--- a/src/containers/ProfileDetails/components/RF/index.js
+++ b/src/containers/ProfileDetails/components/RF/index.js
@@ -205,10 +205,12 @@ const RFForm = ({ form, details }) => {
                 {key !== 'is2dot4GHz' && (
                   <>
                     <Option value="modeAC">AC</Option>
+                    <Option value="modeGN">GN</Option>
                     <Option value="modeA">A</Option>
+                    <Option value="modeAB">AB</Option>
                   </>
                 )}
-                <Option value="modeAX">AX</Option>
+                <Option value="modeX">X</Option>
               </Select>
             );
           },

--- a/src/containers/ProfileDetails/components/RF/index.js
+++ b/src/containers/ProfileDetails/components/RF/index.js
@@ -210,7 +210,7 @@ const RFForm = ({ form, details }) => {
                     <Option value="modeAB">AB</Option>
                   </>
                 )}
-                <Option value="modeX">X</Option>
+                <Option value="modeX">AX</Option>
               </Select>
             );
           },


### PR DESCRIPTION
JIRA: [NETEXP-947](https://connectustechnologies.atlassian.net/browse/NETEXP-947)

## Description
*Summary of this PR*
- Made 5GHz (L) and (U) the same as base 5GHz
- Changed label from X to AX and added it to the 2.4GHz band 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/106065071-bf0da400-60c8-11eb-843f-fcabe2c31f75.png)
![image](https://user-images.githubusercontent.com/55258316/106065093-c6cd4880-60c8-11eb-9ed3-3dfbfbd6cd02.png)
![image](https://user-images.githubusercontent.com/55258316/106065116-cdf45680-60c8-11eb-8252-da39d0d57e47.png)
![image](https://user-images.githubusercontent.com/55258316/106065131-d351a100-60c8-11eb-9d9b-447a2c6a4763.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/106173515-0300b780-6162-11eb-83ac-bc72190921d1.png)
![image](https://user-images.githubusercontent.com/55258316/106173539-0ac05c00-6162-11eb-8157-628fdc82dda1.png)
![image](https://user-images.githubusercontent.com/55258316/106173565-12800080-6162-11eb-812c-3d50cd681bd3.png)
![image](https://user-images.githubusercontent.com/55258316/106173598-19a70e80-6162-11eb-8dcc-96b17fbecf9e.png)

