### PR TITLE
hotfix/OSGraphs: hide y-axis when legend is toggled off

### DIFF
--- a/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
+++ b/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
@@ -87,6 +87,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
           style: { color: '#7cb5ec' },
         }}
         visible={visible}
+        showEmpty={false}
       >
         <YAxis.Title
           style={{
@@ -99,7 +100,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
           <SplineSeries
             key={`cpuCore${i}`}
             id={`cpuCore${i}`}
-            name={`CPU Core ${i}`}
+            name={`CPU ${i} Utilization`}
             data={cpuUsage[i]}
             color="#7cb5ec"
           />
@@ -114,6 +115,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
         }}
         opposite
         visible={visible}
+        showEmpty={false}
       >
         <YAxis.Title
           style={{
@@ -131,6 +133,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
           style: { color: '#f7a35c' },
         }}
         visible={visible}
+        showEmpty={false}
       >
         <YAxis.Title
           style={{

--- a/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
+++ b/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
@@ -100,7 +100,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
           <SplineSeries
             key={`cpuCore${i}`}
             id={`cpuCore${i}`}
-            name={`CPU ${i} Utilization`}
+            name="CPU Utilization"
             data={cpuUsage[i]}
             color="#7cb5ec"
           />


### PR DESCRIPTION
JIRA: [ID](LINK)

## Description
*Summary of this PR*

- Y-Axis is now hidden when corresponding legend toggle is set
- Changed Legend name for CPU from `CPU Core [x]` to `CPU [x] Utilization`

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/106514721-9dcefe00-64a2-11eb-886d-afa07ffb2846.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/106641970-ccf27780-6555-11eb-9811-a45f33861593.png)
![image](https://user-images.githubusercontent.com/55258316/106642004-d67bdf80-6555-11eb-8595-f3f4cd8a95c5.png)

