### PR TITLE
bugfix/WIFI-1486: fixed input range for Client Disconnect Threshold

### DIFF
--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -450,8 +450,8 @@ const General = ({
             renderInputItem,
             {
               min: -100,
-              max: 100,
-              error: '-100 - 100 dBm',
+              max: 0,
+              error: '-100 - 0 dBm',
               addOnText: 'dBm',
               mapName: 'radioMap',
             }

--- a/src/containers/AccessPointDetails/components/General/tests/index.test.js
+++ b/src/containers/AccessPointDetails/components/General/tests/index.test.js
@@ -199,7 +199,7 @@ describe('<General />', () => {
     fireEvent.click(getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - 0 dBm')).toBeVisible();
     });
   });
   it('error if the client disconnect threshold exceeds bounds for the is5GHzU setting', async () => {
@@ -213,7 +213,7 @@ describe('<General />', () => {
     fireEvent.click(getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - 0 dBm')).toBeVisible();
     });
   });
   it('error if the client disconnect threshold exceeds bounds for the is5GHzL setting', async () => {
@@ -227,7 +227,7 @@ describe('<General />', () => {
     fireEvent.click(getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - 0 dBm')).toBeVisible();
     });
   });
 

--- a/src/containers/ProfileDetails/components/RF/index.js
+++ b/src/containers/ProfileDetails/components/RF/index.js
@@ -297,8 +297,8 @@ const RFForm = ({ form, details }) => {
           renderInputItem,
           {
             min: -100,
-            max: 100,
-            error: '-100 - 100 dBm',
+            max: 0,
+            error: '-100 - 0 dBm',
             addOnText: 'dBm',
           }
         )}

--- a/src/containers/ProfileDetails/components/RF/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/RF/tests/index.test.js
@@ -680,7 +680,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - 0 dBm')).toBeVisible();
     });
   });
 
@@ -701,7 +701,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - 0 dBm')).toBeVisible();
     });
   });
 
@@ -722,7 +722,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - 0 dBm')).toBeVisible();
     });
   });
 
@@ -743,7 +743,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - 0 dBm')).toBeVisible();
     });
   });
   // test EIRP Tx Power invalid inputs


### PR DESCRIPTION
JIRA: [WIFI-1487](https://telecominfraproject.atlassian.net/browse/WIFI-1487)

## Description
*Summary of this PR*
Fixed input range for Client Disconnect Threshold  configuration fields.

### Before this PR
*Screenshots of what it looked like before this PR*
General page: 
![image](https://user-images.githubusercontent.com/55258316/107290891-4d711680-6a35-11eb-98de-76a09f559234.png)
RF page: 
![image](https://user-images.githubusercontent.com/55258316/107290950-65e13100-6a35-11eb-98e3-1b56e552a9c2.png)


### After this PR
*Screenshots of what it will look like after this PR*
General page: 
![image](https://user-images.githubusercontent.com/55258316/107290814-303c4800-6a35-11eb-9a32-acd92a658e40.png)

RF page: 
![image](https://user-images.githubusercontent.com/55258316/107290762-1ac71e00-6a35-11eb-8d2e-45c1bcc54dfe.png)

