### PR TITLE
bugfix/WIFI-1532: Remove channel hop config fields

### DIFF
--- a/src/containers/ProfileDetails/components/RF/index.js
+++ b/src/containers/ProfileDetails/components/RF/index.js
@@ -10,7 +10,7 @@ import { RADIOS } from '../../constants';
 const { Item } = Form;
 const { Option } = Select;
 
-const RFForm = ({ form, details }) => {
+const RFForm = ({ form, details, showFields }) => {
   const { radioTypes } = useContext(ThemeContext);
   const currentRadios = Object.keys(details.rfConfigMap).sort();
 
@@ -382,36 +382,39 @@ const RFForm = ({ form, details }) => {
             addOnText: 'sec',
           }
         )}
-        {renderItem(
-          'Non WIFI',
-          ['channelHopSettings', 'nonWifiThresholdInPercentage'],
-          renderInputItem,
-          {
-            min: 0,
-            max: 100,
-            error: '0 - 100%',
-            addOnText: '%',
-          }
-        )}
-        {renderItem(
-          'Non WIFI Time',
-          ['channelHopSettings', 'nonWifiThresholdTimeInSeconds'],
-          renderInputItem,
-          {
-            min: 0,
-            max: 500,
-            error: '0 - 500 seconds',
-            addOnText: 'sec',
-          }
-        )}
-        {renderItem('OBSS Hop Mode', ['channelHopSettings', 'obssHopMode'], renderOptionItem, {
-          dropdown: (
-            <Select className={styles.Field}>
-              <Option value="NON_WIFI">Non-Wifi</Option>
-              <Option value="NON_WIFI_AND_OBSS">Non-Wifi and OBSS</Option>
-            </Select>
-          ),
-        })}
+        {showFields &&
+          renderItem(
+            'Non WIFI',
+            ['channelHopSettings', 'nonWifiThresholdInPercentage'],
+            renderInputItem,
+            {
+              min: 0,
+              max: 100,
+              error: '0 - 100%',
+              addOnText: '%',
+            }
+          )}
+        {showFields &&
+          renderItem(
+            'Non WIFI Time',
+            ['channelHopSettings', 'nonWifiThresholdTimeInSeconds'],
+            renderInputItem,
+            {
+              min: 0,
+              max: 500,
+              error: '0 - 500 seconds',
+              addOnText: 'sec',
+            }
+          )}
+        {showFields &&
+          renderItem('OBSS Hop Mode', ['channelHopSettings', 'obssHopMode'], renderOptionItem, {
+            dropdown: (
+              <Select className={styles.Field}>
+                <Option value="NON_WIFI">Non-Wifi</Option>
+                <Option value="NON_WIFI_AND_OBSS">Non-Wifi and OBSS</Option>
+              </Select>
+            ),
+          })}
       </Card>
     </div>
   );
@@ -420,6 +423,7 @@ const RFForm = ({ form, details }) => {
 RFForm.propTypes = {
   form: PropTypes.instanceOf(Object),
   details: PropTypes.instanceOf(Object),
+  showFields: PropTypes.bool,
 };
 
 RFForm.defaultProps = {
@@ -428,6 +432,7 @@ RFForm.defaultProps = {
     // eslint-disable-next-line no-return-assign, no-sequences
     rfConfigMap: RADIOS.reduce((acc, i) => ((acc[i] = {}), acc), {}),
   },
+  showFields: false,
 };
 
 export default RFForm;

--- a/src/containers/ProfileDetails/components/RF/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/RF/tests/index.test.js
@@ -211,6 +211,7 @@ const mockProps = {
       },
     },
   },
+  showFields: true,
 };
 
 describe('<RFForm />', () => {

--- a/src/containers/ProfileDetails/index.js
+++ b/src/containers/ProfileDetails/index.js
@@ -63,6 +63,7 @@ const ProfileDetails = ({
   loadingOperatorProfiles,
   loadingIdProviderProfiles,
   loadingRFProfiles,
+  showFields,
 }) => {
   const { routes } = useContext(ThemeContext);
   const history = useHistory();
@@ -282,7 +283,9 @@ const ProfileDetails = ({
         )}
         {profileType === PROFILES.radius && <RadiusForm details={details} form={form} />}
         {profileType === PROFILES.bonjour && <BonjourGatewayForm details={details} form={form} />}
-        {profileType === PROFILES.rf && <RFForm details={details} form={form} />}
+        {profileType === PROFILES.rf && (
+          <RFForm details={details} form={form} showFields={showFields} />
+        )}
         {profileType === PROFILES.passpoint && (
           <PasspointProfileForm
             form={form}
@@ -334,6 +337,7 @@ ProfileDetails.propTypes = {
   loadingOperatorProfiles: PropTypes.bool,
   loadingIdProviderProfiles: PropTypes.bool,
   loadingRFProfiles: PropTypes.bool,
+  showFields: PropTypes.bool,
 };
 
 ProfileDetails.defaultProps = {
@@ -359,6 +363,7 @@ ProfileDetails.defaultProps = {
   loadingOperatorProfiles: false,
   loadingIdProviderProfiles: false,
   loadingRFProfiles: false,
+  showFields: false,
 };
 
 export default ProfileDetails;


### PR DESCRIPTION
JIRA: [WIFI-1532](https://telecominfraproject.atlassian.net/browse/WIFI-1532)

## Description
*Summary of this PR*
Removed Non WiFi, NON Wifi Time, and OBSS Hop Mode config fields from TIP. 
This has a related fix made in cmap-ui to show the fields in CMAP.

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/107443351-a9f03680-6b06-11eb-981f-730eee8b3a1c.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/107443311-9ba21a80-6b06-11eb-90dd-cbc47de11fa2.png)
