### PR TITLE
bugfix/NETEXP-1131: Data model Changes

### DIFF
--- a/src/containers/ProfileDetails/components/AccessPoint/index.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/index.js
@@ -352,7 +352,7 @@ const AccessPointForm = ({
                   rules={[
                     {
                       required: syslog,
-                      pattern: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/,
+                      pattern: /^(?!0)(?!.*\.$)((1?\d?\d|25[0-5]|2[0-4]\d)(\.|$)){4}$/,
                       message: 'Enter in the format [0-255].[0-255].[0-255].[0-255]',
                     },
                   ]}

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -562,7 +562,7 @@ const SSIDForm = ({
                     <Option value="enabled">Enabled</Option>
                     <Option value="enabled_reject_if_no_radius_dynamic_vlan">
                       <Tooltip
-                        title="RADIUS Authentication is rejected if Dynamic Vlan is not given by the RADIUS"
+                        title="RADIUS Authentication is rejected if Dynamic VLAN is not given by the RADIUS"
                         text="Qualified Enabled"
                       />
                     </Option>

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -74,6 +74,7 @@ const SSIDForm = ({
       ...radioBasedValues,
       childProfileIds: [],
       radiusAcountingServiceInterval: details?.radiusAcountingServiceInterval || '',
+      dynamicVlan: details?.dynamicVlan || defaultSsidProfile.dynamicVlan,
     });
   }, [form, details]);
 
@@ -213,7 +214,14 @@ const SSIDForm = ({
             <Radio value="BRIDGE" defaultSelected>
               Bridge
             </Radio>
-            <Radio value="NAT">NAT</Radio>
+            <Radio
+              value="NAT"
+              onChange={() => {
+                form.setFieldsValue({ vlan: 'defaultVLAN' });
+              }}
+            >
+              NAT
+            </Radio>
           </Radio.Group>
         </Item>
 
@@ -493,42 +501,77 @@ const SSIDForm = ({
           shouldUpdate={(prevValues, currentValues) => prevValues.vlan !== currentValues.vlan}
         >
           {({ getFieldValue }) => {
-            return getFieldValue('forwardMode') === 'BRIDGE' &&
-              getFieldValue('vlan') === 'customVLAN' ? (
-              <Item label=" " colon={false}>
-                <Item
-                  name="vlanId"
-                  rules={[
-                    {
-                      required: getFieldValue('vlan'),
-                      message: 'Vlan expected between 1 and 4095',
-                    },
-                    () => ({
-                      validator(_rule, value) {
-                        if (
-                          !value ||
-                          (getFieldValue('vlanId') <= 4095 && getFieldValue('vlanId') > 0)
-                        ) {
-                          return Promise.resolve();
-                        }
-                        return Promise.reject(new Error('Vlan expected between 1 and 4095'));
+            return (
+              getFieldValue('forwardMode') === 'BRIDGE' &&
+              getFieldValue('vlan') === 'customVLAN' && (
+                <Item label=" " colon={false}>
+                  <Item
+                    name="vlanId"
+                    rules={[
+                      {
+                        required: getFieldValue('vlan'),
+                        message: 'Vlan expected between 1 and 4095',
                       },
-                    }),
-                  ]}
-                  style={{ marginTop: '10px' }}
-                  hasFeedback
-                >
-                  <Input
-                    className={globalStyles.field}
-                    placeholder="1-4095"
-                    type="number"
-                    min={1}
-                    max={4095}
-                    maxLength={4}
-                  />
+                      () => ({
+                        validator(_rule, value) {
+                          if (
+                            !value ||
+                            (getFieldValue('vlanId') <= 4095 && getFieldValue('vlanId') > 0)
+                          ) {
+                            return Promise.resolve();
+                          }
+                          return Promise.reject(new Error('Vlan expected between 1 and 4095'));
+                        },
+                      }),
+                    ]}
+                    style={{ marginTop: '10px' }}
+                    hasFeedback
+                  >
+                    <Input
+                      className={globalStyles.field}
+                      placeholder="1-4095"
+                      type="number"
+                      min={1}
+                      max={4095}
+                      maxLength={4}
+                    />
+                  </Item>
                 </Item>
+              )
+            );
+          }}
+        </Item>
+
+        <Item
+          noStyle
+          shouldUpdate={(prevValues, currentValues) =>
+            prevValues.forwardMode !== currentValues.forwardMode
+          }
+        >
+          {({ getFieldValue }) => {
+            return (
+              <Item name="dynamicVlan" label="Dynamic VLAN">
+                {getFieldValue('forwardMode') === 'BRIDGE' &&
+                (mode === 'wpa3OnlyEAP' ||
+                  mode === 'wpa3MixedEAP' ||
+                  mode === 'wpa2OnlyRadius' ||
+                  mode === 'wpa2Radius' ||
+                  mode === 'wpaRadius') ? (
+                  <Select className={globalStyles.field} placeholder="Select Dynamic VLAN">
+                    <Option value="disabled">Disabled</Option>
+                    <Option value="enabled">Enabled</Option>
+                    <Option value="enabled_reject_if_no_radius_dynamic_vlan">
+                      <Tooltip
+                        title="RADIUS Authentication is rejected if Dynamic Vlan is not given by the RADIUS"
+                        text="Qualified Enabled"
+                      />
+                    </Option>
+                  </Select>
+                ) : (
+                  <span className={styles.Disclaimer}>Disabled</span>
+                )}
               </Item>
-            ) : null;
+            );
           }}
         </Item>
       </Card>

--- a/src/containers/ProfileDetails/components/SSID/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/SSID/tests/index.test.js
@@ -316,6 +316,8 @@ describe('<SSIDForm />', () => {
       expect(getByText('Use Default VLAN')).toBeVisible();
     });
 
+    fireEvent.click(getByText('Use Custom VLAN'));
+
     fireEvent.change(getByPlaceholderText('1-4095'), { target: { value: null } });
     await waitFor(() => {
       expect(getByText('Vlan expected between 1 and 4095')).toBeVisible();

--- a/src/containers/ProfileDetails/components/constants.js
+++ b/src/containers/ProfileDetails/components/constants.js
@@ -196,6 +196,7 @@ const defaultSsidProfile = {
   ssidAdminState: 'enabled',
   secureMode: 'wpa2OnlyPSK',
   vlanId: 1,
+  dynamicVlan: 'disabled',
   keyStr: '',
   broadcastSsid: 'enabled',
   keyRefresh: 0,
@@ -258,7 +259,7 @@ const defaultApProfile = {
   ntpServer: {
     model_type: 'AutoOrManualString',
     auto: true,
-    value: null,
+    value: 'pool.ntp.org',
   },
   syslogRelay: {
     model_type: 'SyslogRelay',

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -70,6 +70,19 @@ export const formatSsidProfileForm = values => {
     formattedData.radiusServiceId = values.radiusServiceId.value;
   }
 
+  if (
+    !(
+      values.secureMode === 'wpaRadius' ||
+      values.secureMode === 'wpa2Radius' ||
+      values.secureMode === 'wpa2OnlyRadius' ||
+      values.secureMode === 'wpa3OnlyEAP' ||
+      values.secureMode === 'wpa3MixedEAP'
+    ) ||
+    values.forwardMode === 'NAT'
+  ) {
+    formattedData.dynamicVlan = 'disabled';
+  }
+
   return formattedData;
 };
 


### PR DESCRIPTION
JIRA: [NETEXP-1131](https://connectustechnologies.atlassian.net/browse/NETEXP-1131)

## Description
*Summary of this PR*
Data model changes for the AP profile and SSID profile

- Added dynamicVlan field to SSID profile
- Added default server to ntpServer value in AP profile 
- Fixed regex for IP address in AP profile 
- Fixed bug on SSID page where if the user toggled to NAT mode, the vlanID field would remain on the page 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/107554304-c2faf500-6ba3-11eb-95ab-1d301b69abc8.png)
![image](https://user-images.githubusercontent.com/55258316/107554350-d312d480-6ba3-11eb-98db-4ef47522ccb4.png)
![image](https://user-images.githubusercontent.com/55258316/107554538-11a88f00-6ba4-11eb-98d6-c26659148248.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/107554011-5b44aa00-6ba3-11eb-867b-22e08d5abdb9.png)
![image](https://user-images.githubusercontent.com/55258316/107554055-67c90280-6ba3-11eb-8b30-c825fe5599ad.png)
![image](https://user-images.githubusercontent.com/55258316/107554210-a3fc6300-6ba3-11eb-8394-44efc307e38b.png)
![image](https://user-images.githubusercontent.com/55258316/107554244-af4f8e80-6ba3-11eb-9bf7-b22c642fc42a.png)

