### PR TITLE
bugfix/WIFI-1537: Radius authentication on Captive Portal Page

### DIFF
--- a/src/containers/ProfileDetails/components/AccessPoint/index.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/index.js
@@ -485,7 +485,7 @@ const AccessPointForm = ({
           pagination={false}
           rowKey="id"
         />
-        <Item name="childProfileIds" style={{ display: 'none' }}>
+        <Item name="childProfileIds" hidden>
           <Input />
         </Item>
       </Card>

--- a/src/containers/ProfileDetails/components/CaptivePortal/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/index.js
@@ -52,6 +52,7 @@ const formatFile = file => {
 
 const CaptivePortalForm = ({
   details,
+  childProfiles,
   form,
   fileUpload,
   radiusProfiles,
@@ -303,7 +304,12 @@ const CaptivePortalForm = ({
       backgroundRepeat: details.backgroundRepeat || 'no_repeat',
       backgroundPosition: details.backgroundPosition || 'left_top',
       radiusAuthMethod: details.radiusAuthMethod,
-      radiusServiceName: details.radiusServiceName,
+      radiusServiceId:
+        {
+          value: childProfiles?.[0]?.id || null,
+          label: childProfiles?.[0]?.name || null,
+        } || null,
+      childProfileIds: [],
       userList: details.userList,
     });
   }, [form, details]);
@@ -429,7 +435,7 @@ const CaptivePortalForm = ({
             </Select>
           </Item>
           <Item
-            name="radiusServiceName"
+            name="radiusServiceId"
             label="Service"
             rules={[
               {
@@ -447,9 +453,10 @@ const CaptivePortalForm = ({
               onSearch={name => onSearchProfile(name, PROFILES.radius)}
               loading={loadingRadiusProfiles}
               notFoundContent={!loadingRadiusProfiles && <Empty />}
+              labelInValue
             >
               {radiusProfiles.map(profile => (
-                <Option key={profile.id} value={profile.name}>
+                <Option key={profile.id} value={profile.id}>
                   {profile.name}
                 </Option>
               ))}
@@ -681,6 +688,10 @@ const CaptivePortalForm = ({
           <Item name="walledGardenAllowlist" hidden>
             <Input />
           </Item>
+
+          <Item name="childProfileIds" style={{ display: 'none' }}>
+            <Input />
+          </Item>
         </Panel>
       </Collapse>
     </div>
@@ -690,6 +701,7 @@ const CaptivePortalForm = ({
 CaptivePortalForm.propTypes = {
   form: PropTypes.instanceOf(Object),
   details: PropTypes.instanceOf(Object),
+  childProfiles: PropTypes.instanceOf(Array),
   radiusProfiles: PropTypes.instanceOf(Array),
   fileUpload: PropTypes.func,
   onSearchProfile: PropTypes.func,
@@ -700,6 +712,7 @@ CaptivePortalForm.propTypes = {
 CaptivePortalForm.defaultProps = {
   form: null,
   details: {},
+  childProfiles: [],
   radiusProfiles: [],
   fileUpload: () => {},
   onSearchProfile: null,

--- a/src/containers/ProfileDetails/components/CaptivePortal/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/index.js
@@ -304,11 +304,10 @@ const CaptivePortalForm = ({
       backgroundRepeat: details.backgroundRepeat || 'no_repeat',
       backgroundPosition: details.backgroundPosition || 'left_top',
       radiusAuthMethod: details.radiusAuthMethod,
-      radiusServiceId:
-        {
-          value: childProfiles?.[0]?.id || null,
-          label: childProfiles?.[0]?.name || null,
-        } || null,
+      radiusServiceId: {
+        value: childProfiles?.[0]?.id || null,
+        label: childProfiles?.[0]?.name || null,
+      },
       childProfileIds: [],
       userList: details.userList,
     });
@@ -689,7 +688,7 @@ const CaptivePortalForm = ({
             <Input />
           </Item>
 
-          <Item name="childProfileIds" style={{ display: 'none' }}>
+          <Item name="childProfileIds" hidden>
             <Input />
           </Item>
         </Panel>

--- a/src/containers/ProfileDetails/components/PasspointProfile/index.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/index.js
@@ -496,7 +496,7 @@ const PasspointProfileForm = ({
           pagination={false}
           rowKey="id"
         />
-        <Item name="childProfileIds" style={{ display: 'none' }}>
+        <Item name="childProfileIds" hidden>
           <Input />
         </Item>
       </Card>
@@ -540,10 +540,10 @@ const PasspointProfileForm = ({
           </Select>
         </Item>
 
-        <Item name="childProfileIds" style={{ display: 'none' }}>
+        <Item name="childProfileIds" hidden>
           <Input />
         </Item>
-        <Item name="associatedAccessSsidProfileIds" style={{ display: 'none' }}>
+        <Item name="associatedAccessSsidProfileIds" hidden>
           <Input />
         </Item>
       </Card>

--- a/src/containers/ProfileDetails/components/PasspointProfile/index.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/index.js
@@ -496,9 +496,6 @@ const PasspointProfileForm = ({
           pagination={false}
           rowKey="id"
         />
-        <Item name="childProfileIds" hidden>
-          <Input />
-        </Item>
       </Card>
 
       <Card title="Advanced">

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -66,11 +66,10 @@ const SSIDForm = ({
       wepKey: details?.wepConfig?.wepKeys?.[0]?.txKey || '',
       wepDefaultKeyId: details?.wepConfig?.primaryTxKeyId || 1,
       vlanId: details.vlanId || defaultSsidProfile.vlanId,
-      radiusServiceId:
-        {
-          value: childProfiles?.[0]?.id || null,
-          label: childProfiles?.[0]?.name || null,
-        } || null,
+      radiusServiceId: {
+        value: childProfiles?.[0]?.id || null,
+        label: childProfiles?.[0]?.name || null,
+      },
       ...radioBasedValues,
       childProfileIds: [],
       radiusAcountingServiceInterval: details?.radiusAcountingServiceInterval || '',
@@ -588,7 +587,7 @@ const SSIDForm = ({
         </Item>
       </Card>
 
-      <Item name="childProfileIds" style={{ display: 'none' }}>
+      <Item name="childProfileIds" hidden>
         <Input />
       </Item>
     </div>

--- a/src/containers/ProfileDetails/index.js
+++ b/src/containers/ProfileDetails/index.js
@@ -133,6 +133,16 @@ const ProfileDetails = ({
           formattedData = Object.assign(formattedData, formatRadiusForm(values));
         }
         if (profileType === PROFILES.captivePortal) {
+          if (
+            values.authenticationType === 'radius' &&
+            (!values?.radiusServiceId?.value || !values?.radiusServiceId?.label)
+          ) {
+            notification.error({
+              message: 'Error',
+              description: 'RADIUS Profile is required for authentication.',
+            });
+            return;
+          }
           formattedData = Object.assign(formattedData, formatCaptiveForm(values, details));
         }
 
@@ -273,6 +283,7 @@ const ProfileDetails = ({
           <CaptivePortalForm
             form={form}
             details={details}
+            childProfiles={childProfiles}
             fileUpload={fileUpload}
             radiusProfiles={radiusProfiles}
             onSearchProfile={onSearchProfile}

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -163,6 +163,11 @@ export const formatCaptiveForm = (values, details) => {
     formattedData.externalCaptivePortalURL = null;
   }
 
+  if (values.authenticationType === 'radius') {
+    formattedData.radiusServiceId = parseInt(values.radiusServiceId.value, 10);
+    formattedData.childProfileIds.push(parseInt(values.radiusServiceId.value, 10));
+  }
+
   return formattedData;
 };
 


### PR DESCRIPTION
JIRA: [WIFI-1537](https://telecominfraproject.atlassian.net/browse/WIFI-1537)

## Description
*Summary of this PR*
In the Captive Portal Profile, the configured Radius server in Use was not displayed on refreshing the page.

-RADIUS profile id is now included as a child profile of the Captive portal
- Added an alert when RADIUS authentication is selected and user saves the form without selecting a RADIUS service

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*