### PR TITLE
Bugfix/WIFI-1442: Bulk-Edit APs Page Fixes

### DIFF
--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/index.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/index.js
@@ -45,7 +45,7 @@ export const EditableCell = ({
   if (editable) {
     childNode = editing ? (
       <Form.Item
-        data-testid="bulkEditFormElement"
+        data-testid={`bulkEditFormElement-${record.name}-${dataIndex}`}
         style={{
           margin: 0,
         }}
@@ -57,11 +57,16 @@ export const EditableCell = ({
           },
         ]}
       >
-        <Input data-testid="bulkEditFormInput" ref={inputRef} onPressEnter={save} onBlur={save} />
+        <Input
+          data-testid={`bulkEditFormInput-${record.name}-${dataIndex}`}
+          ref={inputRef}
+          onPressEnter={save}
+          onBlur={save}
+        />
       </Form.Item>
     ) : (
       <div
-        data-testid="bulkEditTableCell"
+        data-testid={`bulkEditTableCell-${record.name}-${dataIndex}`}
         className={styles.editableCellValueWrap}
         role="button"
         tabIndex={0}

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/index.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/index.js
@@ -30,14 +30,14 @@ export const EditableCell = ({
     });
   };
 
-  const save = async () => {
-    try {
-      const values = await form.validateFields();
-      toggleEdit();
-      handleSave({ ...record, ...values });
-    } catch (errInfo) {
-      // console.log('Save failed:', errInfo);
-    }
+  const save = () => {
+    form
+      .validateFields()
+      .then(values => {
+        toggleEdit();
+        handleSave({ ...record }, values);
+      })
+      .catch(() => {});
   };
 
   let childNode = children;

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/index.module.scss
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/index.module.scss
@@ -1,9 +1,5 @@
-.editableCell {
-  position: relative;
-}
-
 .editableCellValueWrap {
-  padding: 5px 12px;
+  padding: 5px;
   cursor: pointer;
   border: 1px solid transparent;
   border-radius: 2px;

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/tests/index.test.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/tests/index.test.js
@@ -35,7 +35,6 @@ const mockProps = {
     probeResponseThreshold: [-90, -90, -90],
     snrDrop: [30, 30, 20],
   },
-  handleSave: () => {},
 };
 
 const ENTER = { keyCode: 13 };
@@ -116,6 +115,29 @@ describe('<EditableCell />', () => {
     await waitFor(() => {
       expect(handleSaveSpy).toHaveBeenCalled();
     });
+  });
+
+  it('handleSave default prop test', async () => {
+    const EditableCellComp = () => {
+      const [form] = Form.useForm();
+      return (
+        <div form={form}>
+          <EditableContext.Provider value={form}>
+            <EditableCell {...mockProps} editable />
+          </EditableContext.Provider>
+        </div>
+      );
+    };
+    const { getByTestId } = render(<EditableCellComp />);
+
+    const tableCell = getByTestId(`bulkEditTableCell-${mockProps.record.name}-channel`);
+    fireEvent.click(tableCell);
+    const input = getByTestId(`bulkEditFormInput-${mockProps.record.name}-channel`);
+
+    expect(input).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: '123' } });
+    fireEvent.keyDown(input, ENTER);
   });
 
   it('cell should not be editable when editable flag is false', async () => {

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/tests/index.test.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/tests/index.test.js
@@ -53,9 +53,10 @@ describe('<EditableCell />', () => {
       );
     };
     const { getByTestId } = render(<EditableCellComp />);
-    const tableCell = getByTestId('bulkEditTableCell');
+    const tableCell = getByTestId(`bulkEditTableCell-${mockProps.record.name}-channel`);
     fireEvent.click(tableCell);
-    const formElement = getByTestId('bulkEditFormElement');
+    const formElement = getByTestId(`bulkEditFormElement-${mockProps.record.name}-channel`);
+
     expect(formElement).toBeInTheDocument();
   });
 
@@ -72,11 +73,11 @@ describe('<EditableCell />', () => {
       );
     };
     const { getByTestId } = render(<EditableCellComp />);
-    const tableCell = getByTestId('bulkEditTableCell');
+    const tableCell = getByTestId(`bulkEditTableCell-${mockProps.record.name}-channel`);
     const ENTER = { keyCode: 13 };
     fireEvent.keyDown(tableCell, ENTER);
     fireEvent.click(tableCell);
-    const input = getByTestId('bulkEditFormInput');
+    const input = getByTestId(`bulkEditFormInput-${mockProps.record.name}-channel`);
     fireEvent.change(input, { target: { value: '' } });
     expect(input.value).toBe('');
     fireEvent.keyDown(input, { key: 'Enter', code: 13 });
@@ -99,9 +100,10 @@ describe('<EditableCell />', () => {
     };
     const { getByTestId } = render(<EditableCellComp />);
 
-    const tableCell = getByTestId('bulkEditTableCell');
+    const tableCell = getByTestId(`bulkEditTableCell-${mockProps.record.name}-channel`);
     fireEvent.click(tableCell);
-    const input = getByTestId('bulkEditFormInput');
+    const input = getByTestId(`bulkEditFormInput-${mockProps.record.name}-channel`);
+
     expect(input).toBeInTheDocument();
 
     fireEvent.change(input, { target: { value: '123' } });
@@ -129,31 +131,5 @@ describe('<EditableCell />', () => {
     };
 
     render(<EditableCellComp />);
-  });
-
-  it('cell should be Render When Props Not Provide', async () => {
-    const EditableCellComp = () => {
-      const [form] = Form.useForm();
-      return (
-        <div form={form}>
-          <EditableContext.Provider value={form}>
-            <EditableCell editable />
-          </EditableContext.Provider>
-        </div>
-      );
-    };
-
-    const { getByTestId } = render(<EditableCellComp />);
-    const tableCell = getByTestId('bulkEditTableCell');
-    fireEvent.click(tableCell);
-    const input = getByTestId('bulkEditFormInput');
-    expect(input).toBeInTheDocument();
-
-    fireEvent.change(input, { target: { value: '123' } });
-    await waitFor(() => {
-      expect(input.value).toBe('123');
-    });
-    const ENTER = { keyCode: 13 };
-    fireEvent.keyDown(input, ENTER);
   });
 });

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/tests/index.test.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/tests/index.test.js
@@ -38,6 +38,8 @@ const mockProps = {
   handleSave: () => {},
 };
 
+const ENTER = { keyCode: 13 };
+
 describe('<EditableCell />', () => {
   afterEach(cleanup);
 
@@ -74,7 +76,6 @@ describe('<EditableCell />', () => {
     };
     const { getByTestId } = render(<EditableCellComp />);
     const tableCell = getByTestId(`bulkEditTableCell-${mockProps.record.name}-channel`);
-    const ENTER = { keyCode: 13 };
     fireEvent.keyDown(tableCell, ENTER);
     fireEvent.click(tableCell);
     const input = getByTestId(`bulkEditFormInput-${mockProps.record.name}-channel`);
@@ -111,7 +112,6 @@ describe('<EditableCell />', () => {
     await waitFor(() => {
       expect(input.value).toBe('123');
     });
-    const ENTER = { keyCode: 13 };
     fireEvent.keyDown(input, ENTER);
     await waitFor(() => {
       expect(handleSaveSpy).toHaveBeenCalled();

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/index.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/index.js
@@ -7,8 +7,17 @@ import { EditableCell } from './components/EditableCell';
 import styles from './index.module.scss';
 
 const BulkEditAPTable = ({ tableColumns, tableData, onEditedRows, onLoadMore, isLastPage }) => {
-  const [bulkEditTableData, setTableData] = useState(tableData);
+  const [bulkEditTableData, setTableData] = useState([]);
   const [editedRows, setEditedRows] = useState([]);
+
+  useEffect(() => {
+    onEditedRows(editedRows);
+  }, [editedRows]);
+
+  useEffect(() => {
+    setTableData(tableData);
+  }, [tableData]);
+
   const components = {
     body: {
       row: EditableRow,
@@ -45,10 +54,6 @@ const BulkEditAPTable = ({ tableColumns, tableData, onEditedRows, onLoadMore, is
       }),
     };
   });
-
-  useEffect(() => {
-    onEditedRows(editedRows);
-  }, [editedRows]);
 
   return (
     <>

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/index.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/index.js
@@ -27,43 +27,17 @@ const BulkEditAPTable = ({
     setTableData(tableData);
   }, [tableData]);
 
-  let tempEditedRows = [];
+  const handleSave = (row, values) => {
+    const updatedRow = { ...row };
+    const key = Object.keys(values)[0];
+    updatedRow[key] = JSON.parse(`[${values[key]}]`);
 
-  const handleSave = row => {
-    const newData = [...bulkEditTableData];
-    const channel = JSON.parse(`[${row.channel}]`);
-    const cellSize = JSON.parse(`[${row.cellSize}]`);
-    const probeResponseThreshold = JSON.parse(`[${row.probeResponseThreshold}]`);
-    const clientDisconnectThreshold = JSON.parse(`[${row.clientDisconnectThreshold}]`);
-    const snrDrop = JSON.parse(`[${row.snrDrop}]`);
-    const minLoad = JSON.parse(`[${row.minLoad}]`);
-    const updatedRow = {
-      ...row,
-      channel,
-      cellSize,
-      probeResponseThreshold,
-      clientDisconnectThreshold,
-      snrDrop,
-      minLoad,
-    };
-    const itemIndex = editedRows.findIndex(a => row.key === a.key);
-    const tempRows = [...editedRows];
-
-    if (itemIndex === -1) {
-      tempRows.push(updatedRow);
-      setEditedRows(tempRows);
+    if (!editedRows.some(a => row.key === a.key)) {
+      setEditedRows([...editedRows, updatedRow]);
     } else {
-      const preRow = editedRows[itemIndex];
-      tempEditedRows = [...editedRows];
-      tempEditedRows.splice(itemIndex, 1, { ...preRow, ...updatedRow });
-      setEditedRows(tempEditedRows);
+      setEditedRows(editedRows.map(obj => (obj.id === updatedRow.id ? updatedRow : obj)));
     }
-
-    tempEditedRows.push(updatedRow);
-    const index = newData.findIndex(b => row.key === b.key);
-    const element = newData[index];
-    newData.splice(index, 1, { ...element, ...updatedRow });
-    setTableData(newData);
+    setTableData(bulkEditTableData.map(obj => (obj.id === updatedRow.id ? updatedRow : obj)));
   };
 
   const columns = tableColumns.map(col => {

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/index.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/index.js
@@ -6,15 +6,8 @@ import { EditableRow } from './components/EditableRow';
 import { EditableCell } from './components/EditableCell';
 import styles from './index.module.scss';
 
-const BulkEditAPTable = ({
-  tableColumns,
-  tableData,
-  onEditedRows,
-  onLoadMore,
-  isLastPage,
-  resetEditedRows,
-}) => {
-  const [bulkEditTableData, setTableData] = useState([]);
+const BulkEditAPTable = ({ tableColumns, tableData, onEditedRows, onLoadMore, isLastPage }) => {
+  const [bulkEditTableData, setTableData] = useState(tableData);
   const [editedRows, setEditedRows] = useState([]);
   const components = {
     body: {
@@ -22,10 +15,6 @@ const BulkEditAPTable = ({
       cell: EditableCell,
     },
   };
-
-  useEffect(() => {
-    setTableData(tableData);
-  }, [tableData]);
 
   const handleSave = (row, values) => {
     const updatedRow = { ...row };
@@ -61,18 +50,12 @@ const BulkEditAPTable = ({
     onEditedRows(editedRows);
   }, [editedRows]);
 
-  useEffect(() => {
-    setEditedRows([]);
-  }, [resetEditedRows]);
-
   return (
     <>
       <Table
         data-testid="bulkEditTable"
         components={components}
-        rowClassName={() => {
-          return styles.editableRow;
-        }}
+        rowClassName={styles.editableRow}
         columns={columns}
         dataSource={bulkEditTableData}
         scroll={{ x: 1000 }}
@@ -93,7 +76,6 @@ BulkEditAPTable.propTypes = {
   onEditedRows: PropTypes.func.isRequired,
   onLoadMore: PropTypes.func.isRequired,
   isLastPage: PropTypes.bool,
-  resetEditedRows: PropTypes.bool.isRequired,
 };
 
 BulkEditAPTable.defaultProps = {

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/index.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/index.js
@@ -6,13 +6,8 @@ import { EditableRow } from './components/EditableRow';
 import { EditableCell } from './components/EditableCell';
 import styles from './index.module.scss';
 
-const BulkEditAPTable = ({ tableColumns, tableData, onEditedRows, onLoadMore, isLastPage }) => {
+const BulkEditAPTable = ({ tableColumns, tableData, onLoadMore, isLastPage, setEditedRows }) => {
   const [bulkEditTableData, setTableData] = useState([]);
-  const [editedRows, setEditedRows] = useState([]);
-
-  useEffect(() => {
-    onEditedRows(editedRows);
-  }, [editedRows]);
 
   useEffect(() => {
     setTableData(tableData);
@@ -29,12 +24,8 @@ const BulkEditAPTable = ({ tableColumns, tableData, onEditedRows, onLoadMore, is
     const updatedRow = { ...row };
     const key = Object.keys(values)[0];
     updatedRow[key] = JSON.parse(`[${values[key]}]`);
+    setEditedRows(editedRows => ({ ...editedRows, [updatedRow.key]: updatedRow }));
 
-    if (!editedRows.some(a => row.key === a.key)) {
-      setEditedRows([...editedRows, updatedRow]);
-    } else {
-      setEditedRows(editedRows.map(obj => (obj.id === updatedRow.id ? updatedRow : obj)));
-    }
     setTableData(bulkEditTableData.map(obj => (obj.id === updatedRow.id ? updatedRow : obj)));
   };
 
@@ -78,14 +69,15 @@ const BulkEditAPTable = ({ tableColumns, tableData, onEditedRows, onLoadMore, is
 BulkEditAPTable.propTypes = {
   tableColumns: PropTypes.instanceOf(Array).isRequired,
   tableData: PropTypes.instanceOf(Array),
-  onEditedRows: PropTypes.func.isRequired,
   onLoadMore: PropTypes.func.isRequired,
   isLastPage: PropTypes.bool,
+  setEditedRows: PropTypes.func,
 };
 
 BulkEditAPTable.defaultProps = {
   tableData: [],
   isLastPage: true,
+  setEditedRows: () => {},
 };
 
 export default BulkEditAPTable;

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/tests/index.test.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/tests/index.test.js
@@ -22,14 +22,64 @@ Object.defineProperty(window, 'matchMedia', {
 
 const mockProps = {
   tableColumns: [
-    { dataIndex: 'name', editable: true, key: 'name', title: 'NAME' },
-    { dataIndex: 'name', editable: false, key: 'name', title: 'NAME-1' },
+    {
+      title: 'NAME',
+      dataIndex: 'name',
+      key: 'name',
+    },
+    {
+      title: 'CHANNEL',
+      dataIndex: 'channel',
+      key: 'channel',
+      editable: true,
+    },
+    {
+      title: 'CELL SIZE',
+      dataIndex: 'cellSize',
+      key: 'cellSize',
+      editable: true,
+    },
+    {
+      title: 'PROB RESPONSE THRESHOLD',
+      dataIndex: 'probeResponseThreshold',
+      key: 'probeResponseThreshold',
+      editable: true,
+    },
+    {
+      title: 'CLIENT DISCONNECT THRESHOLD',
+      dataIndex: 'clientDisconnectThreshold',
+      key: 'clientDisconnectThreshold',
+      editable: true,
+    },
+    {
+      title: 'SNR (% DROP)',
+      dataIndex: 'snrDrop',
+      key: 'snrDrop',
+      editable: true,
+    },
+    {
+      title: 'MIN LOAD',
+      dataIndex: 'minLoad',
+      key: 'minLoad',
+      editable: true,
+    },
   ],
   tableData: [
     {
       key: '1',
       id: '1',
       name: 'AP 1',
+      channel: [25, 23, 61],
+      cellSize: [-90, -90, -90],
+      clientDisconnectThreshold: [-90, -90, -90],
+      probeResponseThreshold: [-90, -90, -90],
+      minLoad: [50, 40, 40],
+      snrDrop: [20, 30, 30],
+    },
+    {
+      key: '2',
+      id: '2',
+      name: 'AP 2',
       channel: [25, 23, 61],
       cellSize: [-90, -90, -90],
       clientDisconnectThreshold: [-90, -90, -90],
@@ -58,21 +108,14 @@ describe('<BulkEditAPTableComp />', () => {
       return <BulkEditAPTable {...mockProps} />;
     };
     const { getByTestId } = render(<BulkEditAPTableComp />);
-    const tableCell = getByTestId('bulkEditTableCell');
-    fireEvent.click(tableCell);
-    const input = getByTestId('bulkEditFormInput');
-    fireEvent.click(input);
-
     const ENTER = { keyCode: 13 };
+    const tableCell = getByTestId(`bulkEditTableCell-${mockProps.tableData[0].name}-channel`);
+    fireEvent.click(tableCell);
+    const input = getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-channel`);
+    fireEvent.click(input);
+    fireEvent.change(input, { target: { value: 1 } });
     fireEvent.keyDown(input, ENTER);
-
-    await waitFor(() => expect(getByTestId('bulkEditTableCell')).toBeInTheDocument());
-    const newTableCell = getByTestId('bulkEditTableCell');
-    fireEvent.click(newTableCell);
-    const newInput = getByTestId('bulkEditFormInput');
-    fireEvent.click(newInput);
-
-    fireEvent.keyDown(newInput, ENTER);
-    await waitFor(() => expect(getByTestId('bulkEditTableCell')).toBeInTheDocument());
+    fireEvent.click(input);
+    await waitFor(() => expect(input).toBeInTheDocument());
   });
 });

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/tests/index.test.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/tests/index.test.js
@@ -88,7 +88,6 @@ const mockProps = {
       snrDrop: [20, 30, 30],
     },
   ],
-  onEditedRows: jest.fn(),
   onLoadMore: jest.fn(),
   isLastPage: false,
 };

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/tests/index.test.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/tests/index.test.js
@@ -91,7 +91,6 @@ const mockProps = {
   onEditedRows: jest.fn(),
   onLoadMore: jest.fn(),
   isLastPage: false,
-  resetEditedRows: false,
 };
 
 describe('<BulkEditAPTableComp />', () => {
@@ -109,13 +108,19 @@ describe('<BulkEditAPTableComp />', () => {
     };
     const { getByTestId } = render(<BulkEditAPTableComp />);
     const ENTER = { keyCode: 13 };
+
     const tableCell = getByTestId(`bulkEditTableCell-${mockProps.tableData[0].name}-channel`);
     fireEvent.click(tableCell);
     const input = getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-channel`);
     fireEvent.click(input);
     fireEvent.change(input, { target: { value: 1 } });
     fireEvent.keyDown(input, ENTER);
+
+    await waitFor(() => expect(tableCell).toBeVisible());
+
+    fireEvent.click(tableCell);
     fireEvent.click(input);
-    await waitFor(() => expect(input).toBeInTheDocument());
+    fireEvent.change(input, { target: { value: 1 } });
+    fireEvent.keyDown(input, ENTER);
   });
 });

--- a/src/components/BulkEditAccessPoints/index.js
+++ b/src/components/BulkEditAccessPoints/index.js
@@ -30,15 +30,6 @@ const BulkEditAccessPoints = ({
     <Breadcrumb.Item key={location.id}>{location.name}</Breadcrumb.Item>
   ));
 
-  const handleOnSave = () => {
-    const editedRowsArr = [];
-    Object.keys(editedRows).forEach(key => {
-      editedRowsArr.push(editedRows[key]);
-    });
-
-    return editedRowsArr;
-  };
-
   return (
     <div>
       <Button
@@ -57,7 +48,7 @@ const BulkEditAccessPoints = ({
         </div>
         <Button
           onClick={() => {
-            onSaveChanges(handleOnSave());
+            onSaveChanges(editedRows);
             setEditedRows(null);
           }}
           disabled={!editedRows}

--- a/src/components/BulkEditAccessPoints/index.js
+++ b/src/components/BulkEditAccessPoints/index.js
@@ -21,7 +21,6 @@ const BulkEditAccessPoints = ({
   const { routes } = useContext(ThemeContext);
   const history = useHistory();
   const [editedRows, setEditedRows] = useState([]);
-  const [resetEditedRows, setRestEditedRows] = useState(false);
 
   const handleBackClick = () => {
     history.push(routes.accessPoints);
@@ -54,7 +53,7 @@ const BulkEditAccessPoints = ({
         <Button
           onClick={() => {
             onSaveChanges(editedRows);
-            setRestEditedRows(!resetEditedRows);
+            setEditedRows([]);
           }}
           disabled={editedRows.length <= 0}
           className={styles.saveBtn}
@@ -68,7 +67,6 @@ const BulkEditAccessPoints = ({
         onEditedRows={handleEditedRows}
         onLoadMore={onLoadMore}
         isLastPage={isLastPage}
-        resetEditedRows={resetEditedRows}
       />
     </div>
   );

--- a/src/components/BulkEditAccessPoints/index.js
+++ b/src/components/BulkEditAccessPoints/index.js
@@ -57,8 +57,9 @@ const BulkEditAccessPoints = ({
           }}
           disabled={editedRows.length <= 0}
           className={styles.saveBtn}
+          type="primary"
         >
-          SAVE CHANGES
+          Save
         </Button>
       </div>
       <BulkEditAPTable

--- a/src/components/BulkEditAccessPoints/index.js
+++ b/src/components/BulkEditAccessPoints/index.js
@@ -20,19 +20,24 @@ const BulkEditAccessPoints = ({
 }) => {
   const { routes } = useContext(ThemeContext);
   const history = useHistory();
-  const [editedRows, setEditedRows] = useState([]);
+  const [editedRows, setEditedRows] = useState(null);
 
   const handleBackClick = () => {
     history.push(routes.accessPoints);
   };
 
-  const handleEditedRows = rows => {
-    setEditedRows(rows);
-  };
-
   const breadCrumbs = breadcrumbPath.map(location => (
     <Breadcrumb.Item key={location.id}>{location.name}</Breadcrumb.Item>
   ));
+
+  const handleOnSave = () => {
+    const editedRowsArr = [];
+    Object.keys(editedRows).forEach(key => {
+      editedRowsArr.push(editedRows[key]);
+    });
+
+    return editedRowsArr;
+  };
 
   return (
     <div>
@@ -52,10 +57,10 @@ const BulkEditAccessPoints = ({
         </div>
         <Button
           onClick={() => {
-            onSaveChanges(editedRows);
-            setEditedRows([]);
+            onSaveChanges(handleOnSave());
+            setEditedRows(null);
           }}
-          disabled={editedRows.length <= 0}
+          disabled={!editedRows}
           className={styles.saveBtn}
           type="primary"
         >
@@ -65,7 +70,7 @@ const BulkEditAccessPoints = ({
       <BulkEditAPTable
         tableColumns={tableColumns}
         tableData={tableData}
-        onEditedRows={handleEditedRows}
+        setEditedRows={setEditedRows}
         onLoadMore={onLoadMore}
         isLastPage={isLastPage}
       />

--- a/src/components/BulkEditAccessPoints/index.js
+++ b/src/components/BulkEditAccessPoints/index.js
@@ -56,6 +56,7 @@ const BulkEditAccessPoints = ({
             onSaveChanges(editedRows);
             setRestEditedRows(!resetEditedRows);
           }}
+          disabled={editedRows.length <= 0}
           className={styles.saveBtn}
         >
           SAVE CHANGES

--- a/src/components/BulkEditAccessPoints/tests/index.test.js
+++ b/src/components/BulkEditAccessPoints/tests/index.test.js
@@ -105,7 +105,9 @@ describe('<BulkEditAccessPoints />', () => {
         <BulkEditAccessPoints {...mockProps} onSaveChanges={onSaveChangesSpy} />
       </Router>
     );
-    fireEvent.click(getByRole('button', { name: /save changes/i }));
+    const button = getByRole('button', { name: /save changes/i });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
     expect(onSaveChangesSpy).toHaveBeenCalledTimes(0);
   });
 

--- a/src/components/BulkEditAccessPoints/tests/index.test.js
+++ b/src/components/BulkEditAccessPoints/tests/index.test.js
@@ -254,6 +254,24 @@ describe('<BulkEditAccessPoints />', () => {
     });
   });
 
+  it('error should be shown if any input has an invalid configuration', async () => {
+    const { getByText, getByTestId } = render(
+      <Router>
+        <BulkEditAccessPoints {...mockProps} />
+      </Router>
+    );
+
+    const tableCell = getByTestId(`bulkEditTableCell-${mockProps.tableData[0].name}-minLoad`);
+    fireEvent.click(tableCell);
+    const input = getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-minLoad`);
+    fireEvent.change(input, { target: { value: '1,1,1,1,1' } });
+    fireEvent.keyDown(input, ENTER);
+
+    await waitFor(() => {
+      expect(getByText('Please enter a valid configuration')).toBeVisible();
+    });
+  });
+
   it('if isLastPage is true Load More button should not be visible', async () => {
     const { queryByRole } = render(
       <Router>

--- a/src/components/BulkEditAccessPoints/tests/index.test.js
+++ b/src/components/BulkEditAccessPoints/tests/index.test.js
@@ -22,42 +22,42 @@ Object.defineProperty(window, 'matchMedia', {
 const mockProps = {
   tableColumns: [
     {
-      title: 'NAME',
+      title: 'Name',
       dataIndex: 'name',
       key: 'name',
     },
     {
-      title: 'CHANNEL',
+      title: 'Channel',
       dataIndex: 'channel',
       key: 'channel',
       editable: true,
     },
     {
-      title: 'CELL SIZE',
+      title: 'Cell Size',
       dataIndex: 'cellSize',
       key: 'cellSize',
       editable: true,
     },
     {
-      title: 'PROB RESPONSE THRESHOLD',
+      title: 'Probe Response Threshold',
       dataIndex: 'probeResponseThreshold',
       key: 'probeResponseThreshold',
       editable: true,
     },
     {
-      title: 'CLIENT DISCONNECT THRESHOLD',
+      title: 'Client Disconnect Threshold',
       dataIndex: 'clientDisconnectThreshold',
       key: 'clientDisconnectThreshold',
       editable: true,
     },
     {
-      title: 'SNR (% DROP)',
+      title: 'SNR (% Drop)',
       dataIndex: 'snrDrop',
       key: 'snrDrop',
       editable: true,
     },
     {
-      title: 'MIN LOAD',
+      title: 'Min Load',
       dataIndex: 'minLoad',
       key: 'minLoad',
       editable: true,
@@ -84,6 +84,9 @@ const mockProps = {
     { id: 8, name: 'Ottawa' },
   ],
 };
+
+const ENTER = { keyCode: 13 };
+
 describe('<BulkEditAccessPoints />', () => {
   afterEach(cleanup);
   const URL = ROUTES.accessPoints;
@@ -98,20 +101,20 @@ describe('<BulkEditAccessPoints />', () => {
     expect(window.location.pathname).toEqual(URL);
   });
 
-  it('onSaveChanges should not be called when Save Changes button is clicked on an unedited table', () => {
+  it('onSaveChanges should not be called when Save button is clicked on an unedited table', () => {
     const onSaveChangesSpy = jest.fn();
     const { getByRole } = render(
       <Router>
         <BulkEditAccessPoints {...mockProps} onSaveChanges={onSaveChangesSpy} />
       </Router>
     );
-    const button = getByRole('button', { name: /save changes/i });
+    const button = getByRole('button', { name: /save/i });
     expect(button).toBeDisabled();
     fireEvent.click(button);
     expect(onSaveChangesSpy).toHaveBeenCalledTimes(0);
   });
 
-  it('onSaveChanges should be called when Save Changes button is clicked on an edited table', async () => {
+  it('onSaveChanges should be called when Save button is clicked on an edited table', async () => {
     const onSaveChangesSpy = jest.fn();
     const { getByRole, getByTestId } = render(
       <Router>
@@ -119,17 +122,136 @@ describe('<BulkEditAccessPoints />', () => {
       </Router>
     );
 
-    const button = getByRole('button', { name: /save changes/i });
+    const button = getByRole('button', { name: /save/i });
     expect(button).toBeDisabled();
-    const ENTER = { keyCode: 13 };
     const tableCell = getByTestId(`bulkEditTableCell-${mockProps.tableData[0].name}-channel`);
     fireEvent.click(tableCell);
     const input = getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-channel`);
-    fireEvent.change(input, { target: { value: 1 } });
+    fireEvent.click(input);
     fireEvent.keyDown(input, ENTER);
     await waitFor(() => expect(button).not.toBeDisabled());
     fireEvent.click(button);
     expect(onSaveChangesSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('error should be shown if Channel input is outside range', async () => {
+    const { getByText, getByTestId } = render(
+      <Router>
+        <BulkEditAccessPoints {...mockProps} />
+      </Router>
+    );
+
+    const tableCell = getByTestId(`bulkEditTableCell-${mockProps.tableData[0].name}-channel`);
+    fireEvent.click(tableCell);
+    const input = getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-channel`);
+    fireEvent.change(input, { target: { value: 166 } });
+    fireEvent.keyDown(input, ENTER);
+
+    await waitFor(() => {
+      expect(getByText('Channel can be a number between 1 and 165')).toBeVisible();
+    });
+  });
+
+  it('error should be shown if Cell Size input is outside range', async () => {
+    const { getByText, getByTestId } = render(
+      <Router>
+        <BulkEditAccessPoints {...mockProps} />
+      </Router>
+    );
+
+    const tableCell = getByTestId(`bulkEditTableCell-${mockProps.tableData[0].name}-cellSize`);
+    fireEvent.click(tableCell);
+    const input = getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-cellSize`);
+    fireEvent.change(input, { target: { value: 101 } });
+    fireEvent.keyDown(input, ENTER);
+
+    await waitFor(() => {
+      expect(getByText('Cell Size can be a number between -100 and 100')).toBeVisible();
+    });
+  });
+
+  it('error should be shown if Probe Response Threshold  input is outside range', async () => {
+    const { getByText, getByTestId } = render(
+      <Router>
+        <BulkEditAccessPoints {...mockProps} />
+      </Router>
+    );
+
+    const tableCell = getByTestId(
+      `bulkEditTableCell-${mockProps.tableData[0].name}-probeResponseThreshold`
+    );
+    fireEvent.click(tableCell);
+    const input = getByTestId(
+      `bulkEditFormInput-${mockProps.tableData[0].name}-probeResponseThreshold`
+    );
+    fireEvent.change(input, { target: { value: 101 } });
+    fireEvent.keyDown(input, ENTER);
+
+    await waitFor(() => {
+      expect(
+        getByText('Probe Response Threshold can be a number between -100 and 100')
+      ).toBeVisible();
+    });
+  });
+
+  it('error should be shown if Client Disconnect Threshold input is outside range', async () => {
+    const { getByText, getByTestId } = render(
+      <Router>
+        <BulkEditAccessPoints {...mockProps} />
+      </Router>
+    );
+
+    const tableCell = getByTestId(
+      `bulkEditTableCell-${mockProps.tableData[0].name}-clientDisconnectThreshold`
+    );
+    fireEvent.click(tableCell);
+    const input = getByTestId(
+      `bulkEditFormInput-${mockProps.tableData[0].name}-clientDisconnectThreshold`
+    );
+    fireEvent.change(input, { target: { value: 101 } });
+    fireEvent.keyDown(input, ENTER);
+
+    await waitFor(() => {
+      expect(
+        getByText('Client Disconnect Threshold can be a number between -100 and 100')
+      ).toBeVisible();
+    });
+  });
+
+  it('error should be shown if SNR (% Drop) input is outside range', async () => {
+    const { getByText, getByTestId } = render(
+      <Router>
+        <BulkEditAccessPoints {...mockProps} />
+      </Router>
+    );
+
+    const tableCell = getByTestId(`bulkEditTableCell-${mockProps.tableData[0].name}-snrDrop`);
+    fireEvent.click(tableCell);
+    const input = getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-snrDrop`);
+    fireEvent.change(input, { target: { value: 101 } });
+    fireEvent.keyDown(input, ENTER);
+
+    await waitFor(() => {
+      expect(getByText('SNR (% Drop) can be a number between 1 and 100')).toBeVisible();
+    });
+  });
+
+  it('error should be shown if Min Load input is outside range', async () => {
+    const { getByText, getByTestId } = render(
+      <Router>
+        <BulkEditAccessPoints {...mockProps} />
+      </Router>
+    );
+
+    const tableCell = getByTestId(`bulkEditTableCell-${mockProps.tableData[0].name}-minLoad`);
+    fireEvent.click(tableCell);
+    const input = getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-minLoad`);
+    fireEvent.change(input, { target: { value: 101 } });
+    fireEvent.keyDown(input, ENTER);
+
+    await waitFor(() => {
+      expect(getByText('Min Load can be a number between 1 and 100')).toBeVisible();
+    });
   });
 
   it('if isLastPage is true Load More button should not be visible', async () => {


### PR DESCRIPTION
JIRA: [WIFI-1442](https://telecominfraproject.atlassian.net/browse/WIFI-1442)

## Description
*Summary of this PR*
- Save button is disabled by default and is only enabled when the user edits a row
- The saving functionality is changed so it only saves the row field on an edit, and not the entire row
- Added input validation to for each table field

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/107819012-77348100-6d46-11eb-93a1-c4a77b92f69b.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/108132376-b8979a00-7080-11eb-9950-2a524a27f531.png)
