### PR TITLE
feature/NETEXP-1178: Remove overflow from AppLayout

### DIFF
--- a/src/containers/AppLayout/index.js
+++ b/src/containers/AppLayout/index.js
@@ -70,11 +70,7 @@ const AppLayout = ({
   }, [screenSize]);
 
   return (
-    <Layout
-      className={`${styles.MainLayout} ${isCollapsed ? styles.collapsed : ''} ${
-        isMobile ? styles.mobile : ''
-      }`}
-    >
+    <Layout className={`${isCollapsed ? styles.collapsed : ''} ${isMobile ? styles.mobile : ''}`}>
       <Navbar
         menuItems={menuItems}
         mobileMenuItems={mobileMenuItems}

--- a/src/containers/AppLayout/index.module.scss
+++ b/src/containers/AppLayout/index.module.scss
@@ -1,9 +1,5 @@
 @import 'styles/variables';
 
-.MainLayout {
-  overflow: auto;
-}
-
 .Content {
   margin-top: $header-height;
 }


### PR DESCRIPTION
## Description
Having `overflow: auto` prevents `position: sticky` from working on all children and subchildren. This PR removes it.