### PR TITLE
hotfix/WIFI-1449: Long text can break table columns

### DIFF
--- a/src/containers/AutoProvision/index.js
+++ b/src/containers/AutoProvision/index.js
@@ -109,13 +109,13 @@ const AutoProvision = ({
       title: 'MODEL',
       dataIndex: 'model',
       key: 'model',
-      width: 100,
+      width: 150,
     },
     {
       title: 'PROFILE',
       dataIndex: 'profileId',
       key: 'profileId',
-      width: 700,
+      width: 800,
       render: i => profilesById[i]?.name || i,
     },
     {

--- a/src/containers/Firmware/index.js
+++ b/src/containers/Firmware/index.js
@@ -128,7 +128,7 @@ const Firmware = ({
       title: 'MODEL ID',
       dataIndex: 'modelId',
       key: 'modelId',
-      width: 100,
+      width: 150,
     },
     {
       title: 'VERSION',
@@ -186,7 +186,7 @@ const Firmware = ({
       title: 'MODEL ID',
       dataIndex: 'modelId',
       key: 'modelIdFirmware',
-      width: 100,
+      width: 150,
     },
     {
       title: 'VERSION',

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,0 +1,3 @@
+:global(.ant-table) {
+  word-break: break-all;
+}


### PR DESCRIPTION
JIRA: [WIFI-1449](https://telecominfraproject.atlassian.net/browse/WIFI-1449)

## Description
*Summary of this PR*
Fixed global styles for tables so that long-text does not break table columns.

### Before this PR
*Screenshots of what it looked like before this PR*
![Screen Shot 2021-02-18 at 10 42 38 AM](https://user-images.githubusercontent.com/55258316/108383109-7a60be80-71d7-11eb-901b-2b18ba230d42.png)

### After this PR
*Screenshots of what it will look like after this PR*
![Screen Shot 2021-02-18 at 10 45 15 AM](https://user-images.githubusercontent.com/55258316/108383120-7c2a8200-71d7-11eb-978c-c2234745e29d.png)