### PR TITLE
hotfix/UnmountModalFix: Improve modal performance

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -32,6 +32,7 @@ const Modal = ({
           </div>
         </>
       }
+      destroyOnClose
       {...restProps}
     >
       {content}

--- a/src/containers/AccessPointDetails/components/Firmware/tests/index.test.js
+++ b/src/containers/AccessPointDetails/components/Firmware/tests/index.test.js
@@ -114,7 +114,7 @@ describe('<Firmware />', () => {
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(queryByText('Confirm downloading, flashing, rebooting?')).not.toBeVisible();
+      expect(queryByText('Confirm downloading, flashing, rebooting?')).not.toBeInTheDocument();
     });
   });
 

--- a/src/containers/AccessPointDetails/tests/index.test.js
+++ b/src/containers/AccessPointDetails/tests/index.test.js
@@ -334,7 +334,7 @@ describe('<AccessPointDetails />', () => {
   });
 
   it('Cancel button on delete AP modal should hide modal', async () => {
-    const { getByRole, getAllByRole, getByText } = render(
+    const { getByRole, getAllByRole, getByText, queryByText } = render(
       <MemoryRouter initialEntries={['/network/access-points/1/general']}>
         <Route path="/network/access-points/:id/:tab">
           <AccessPointDetails {...defaultProps} />
@@ -343,12 +343,12 @@ describe('<AccessPointDetails />', () => {
     );
 
     fireEvent.click(getAllByRole('button', { name: 'Delete' })[1]);
-    const paragraph = getByText(/Are you sure you want to delete this access point:/i);
-
-    expect(paragraph).toBeVisible();
+    expect(getByText(/Are you sure you want to delete this access point:/i)).toBeVisible();
     fireEvent.click(getByRole('button', { name: /cancel/i }));
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(
+        queryByText(/Are you sure you want to delete this access point:/i)
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/containers/Accounts/index.js
+++ b/src/containers/Accounts/index.js
@@ -23,13 +23,7 @@ const Accounts = ({
 }) => {
   const [editModal, setEditModal] = useState(false);
   const [addModal, setAddModal] = useState(false);
-  const [activeUser, setActiveUser] = useState({
-    id: 0,
-    email: '',
-    roles: [],
-    customerId: '',
-    lastModifiedTimestamp: 0,
-  });
+  const [activeUser, setActiveUser] = useState({});
 
   const deleteUser = () => {
     const { id } = activeUser;
@@ -74,11 +68,7 @@ const Accounts = ({
           onClick={() => {
             setEditModal(true);
             setActiveUser({
-              id: record.id,
-              email: record.email,
-              roles: record.roles,
-              customerId: record.customerId,
-              lastModifiedTimestamp: record.lastModifiedTimestamp,
+              ...record,
             });
           }}
         />
@@ -95,11 +85,7 @@ const Accounts = ({
             title={`delete-${record.email}`}
             extraOnClick={() => {
               setActiveUser({
-                id: record.id,
-                email: record.email,
-                roles: record.roles,
-                customerId: record.customerId,
-                lastModifiedTimestamp: record.lastModifiedTimestamp,
+                ...record,
               });
             }}
             onSuccess={deleteUser}
@@ -158,7 +144,7 @@ Accounts.propTypes = {
   data: PropTypes.instanceOf(Array),
   onLoadMore: PropTypes.func,
   isLastPage: PropTypes.bool,
-  currentUserId: PropTypes.number,
+  currentUserId: PropTypes.string,
   isAuth0Enabled: PropTypes.bool,
 };
 

--- a/src/containers/Accounts/tests/index.test.js
+++ b/src/containers/Accounts/tests/index.test.js
@@ -115,38 +115,38 @@ describe('<Accounts />', () => {
   });
 
   it('cancel button click should hide Add User modal', async () => {
-    const { getByRole, getByText } = render(<Accounts {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<Accounts {...mockProps} />);
 
     fireEvent.click(getByRole('button', { name: /addaccount/i }));
     expect(getByText('Add User', { selector: 'div' })).toBeVisible();
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Add User', { selector: 'div' })).not.toBeVisible();
+      expect(queryByText('Add User', { selector: 'div' })).not.toBeInTheDocument();
     });
   });
 
   it('cancel button click should hide Edit User Modal', async () => {
-    const { getByRole, getByText } = render(<Accounts {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<Accounts {...mockProps} />);
 
     fireEvent.click(getByRole('button', { name: /edit/i }));
     expect(getByText('Edit User')).toBeVisible();
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Edit User')).not.toBeVisible();
+      expect(queryByText('Edit User')).not.toBeInTheDocument();
     });
   });
 
   it('cancel button click should hide Delete User Modal', async () => {
-    const { getByRole, getByText } = render(<Accounts {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<Accounts {...mockProps} />);
 
     fireEvent.click(getByRole('button', { name: `delete-${mockProps.data[0].email}` }));
     expect(getByText('Are you sure?')).toBeVisible();
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Are you sure?')).not.toBeVisible();
+      expect(queryByText('Are you sure?')).not.toBeInTheDocument();
     });
   });
 

--- a/src/containers/AutoProvision/tests/index.test.js
+++ b/src/containers/AutoProvision/tests/index.test.js
@@ -306,7 +306,7 @@ describe('<AutoProvision />', () => {
   });
 
   it('Cancel button press should hide Add Model modal', async () => {
-    const { getByRole, getByText } = render(<AutoProvision {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<AutoProvision {...mockProps} />);
 
     fireEvent.click(getByRole('button', { name: /add model/i }));
 
@@ -315,12 +315,12 @@ describe('<AutoProvision />', () => {
     fireEvent.click(getByRole('button', { name: /cancel/i }));
 
     await waitFor(() => {
-      expect(getByText('Add Model', { selector: 'div' })).not.toBeVisible();
+      expect(queryByText('Add Model', { selector: 'div' })).not.toBeInTheDocument();
     });
   });
 
   it('Cancel button press should hide Edit Model modal', async () => {
-    const { getByRole, getByText } = render(<AutoProvision {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<AutoProvision {...mockProps} />);
 
     fireEvent.click(
       getByRole('button', {
@@ -333,12 +333,12 @@ describe('<AutoProvision />', () => {
     fireEvent.click(getByRole('button', { name: /cancel/i }));
 
     await waitFor(() => {
-      expect(getByText('Edit Model')).not.toBeVisible();
+      expect(queryByText('Edit Model')).not.toBeInTheDocument();
     });
   });
 
   it('Cancel button press should hide Delete Model modal', async () => {
-    const { getByRole, getByText } = render(<AutoProvision {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<AutoProvision {...mockProps} />);
 
     fireEvent.click(
       getByRole('button', {
@@ -353,7 +353,7 @@ describe('<AutoProvision />', () => {
     fireEvent.click(getByRole('button', { name: /cancel/i }));
 
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(queryByText(/Are you sure you want to delete the model:/i)).not.toBeInTheDocument();
     });
   });
 

--- a/src/containers/BlockedList/tests/index.test.js
+++ b/src/containers/BlockedList/tests/index.test.js
@@ -92,7 +92,7 @@ describe('<BlockedList />', () => {
   });
 
   it('Cancel button press should hide ADD Client modal', async () => {
-    const { getByRole, getByText } = render(
+    const { getByRole, getByText, queryByText } = render(
       <Router>
         <BlockedList {...mockProps} />
       </Router>
@@ -100,13 +100,12 @@ describe('<BlockedList />', () => {
 
     fireEvent.click(getByRole('button', { name: 'Add Client' }));
 
-    const paragraph = getByText('Add Client', { selector: 'div' });
-    expect(paragraph).toBeVisible();
+    expect(getByText('Add Client', { selector: 'div' })).toBeVisible();
 
     fireEvent.click(getByRole('button', { name: /cancel/i }));
 
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(queryByText('Add Client', { selector: 'div' })).not.toBeInTheDocument();
     });
   });
 
@@ -129,7 +128,7 @@ describe('<BlockedList />', () => {
   });
 
   it('Cancel button press should hide Delete MAC modal', async () => {
-    const { getByRole, getByText } = render(
+    const { getByRole, getByText, queryByText } = render(
       <Router>
         <BlockedList {...mockProps} />
       </Router>
@@ -148,13 +147,13 @@ describe('<BlockedList />', () => {
     fireEvent.click(getByRole('button', { name: /cancel/i }));
 
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(queryByText(/Are you sure you want to remove the Client:/i)).not.toBeInTheDocument();
     });
   });
 
   it('Delete button press on Delete MAC Modal should call onUpdateClient', async () => {
     const submitSpy = jest.fn();
-    const { getByRole, getByText } = render(
+    const { getByRole, getByText, queryByText } = render(
       <Router>
         <BlockedList {...mockProps} onUpdateClient={submitSpy} />
       </Router>
@@ -175,7 +174,7 @@ describe('<BlockedList />', () => {
 
     await waitFor(() => {
       expect(submitSpy).toBeCalledTimes(1);
-      expect(paragraph).not.toBeVisible();
+      expect(queryByText(/Are you sure you want to remove the Client:/i)).not.toBeInTheDocument();
     });
   });
 

--- a/src/containers/Firmware/tests/index.test.js
+++ b/src/containers/Firmware/tests/index.test.js
@@ -161,7 +161,7 @@ describe('<Firmware />', () => {
   });
 
   it('cancel button click should hide Add Model Target Version modal', async () => {
-    const { getByRole, getByText } = render(<Firmware {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<Firmware {...mockProps} />);
 
     fireEvent.click(getByRole('button', { name: /add Model Target Version/i }));
 
@@ -170,12 +170,12 @@ describe('<Firmware />', () => {
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Add Model Target Version', { selector: 'div' })).not.toBeVisible();
+      expect(queryByText('Add Model Target Version', { selector: 'div' })).not.toBeInTheDocument();
     });
   });
 
   it('cancel button click should hide Edit Model Target Version Modal', async () => {
-    const { getByRole, getByText } = render(<Firmware {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<Firmware {...mockProps} />);
 
     fireEvent.click(
       getByRole('button', { name: `edit-track-${mockProps.firmwareData[0].modelId}` })
@@ -185,12 +185,12 @@ describe('<Firmware />', () => {
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Edit Model Target Version')).not.toBeVisible();
+      expect(queryByText('Edit Model Target Version')).not.toBeInTheDocument();
     });
   });
 
   it('cancel button click should hide Delete Model Target Version Modal', async () => {
-    const { getByRole, getByText } = render(<Firmware {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<Firmware {...mockProps} />);
     fireEvent.click(
       getByRole('button', { name: `delete-track-${mockProps.firmwareData[0].modelId}` })
     );
@@ -201,7 +201,9 @@ describe('<Firmware />', () => {
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(
+        queryByText(/Are you sure you want to delete the model target version:/i)
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -273,7 +275,7 @@ describe('<Firmware />', () => {
   });
 
   it('cancel button click should hide Add Firmware Vesion modal', async () => {
-    const { getByRole, getByText } = render(<Firmware {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<Firmware {...mockProps} />);
 
     fireEvent.click(getByRole('button', { name: /add version/i }));
 
@@ -282,26 +284,27 @@ describe('<Firmware />', () => {
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Add Firmware Version')).not.toBeVisible();
+      expect(queryByText('Add Firmware Version')).not.toBeInTheDocument();
     });
   });
 
   it('cancel button click should hide Edit Firmware Version Modal', async () => {
-    const { getByRole, getByText } = render(<Firmware {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<Firmware {...mockProps} />);
 
     fireEvent.click(
       getByRole('button', { name: `edit-firmware-${mockProps.firmwareData[2].modelId}` })
     );
+
     expect(getByText('Edit Firmware Version')).toBeVisible();
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Edit Firmware Version')).not.toBeVisible();
+      expect(queryByText('Edit Firmware Version')).not.toBeInTheDocument();
     });
   });
 
   it('cancel button click should hide Delete Firmware Version Modal', async () => {
-    const { getByRole, getByText } = render(<Firmware {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<Firmware {...mockProps} />);
     fireEvent.click(
       getByRole('button', { name: `delete-firmware-${mockProps.firmwareData[2].modelId}` })
     );
@@ -312,7 +315,7 @@ describe('<Firmware />', () => {
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(queryByText(/Are you sure you want to delete the version:/i)).not.toBeInTheDocument();
     });
   });
 

--- a/src/containers/Profile/index.js
+++ b/src/containers/Profile/index.js
@@ -15,12 +15,7 @@ import styles from './index.module.scss';
 const Profile = ({ data, onReload, onLoadMore, isLastPage, onDeleteProfile }) => {
   const { routes } = useContext(ThemeContext);
   const history = useHistory();
-  const [activeProfile, setActiveProfile] = useState({
-    id: 0,
-    name: '',
-    profileType: '',
-    __typename: '',
-  });
+  const [activeProfile, setActiveProfile] = useState({});
 
   const deleteProfile = () => {
     const { id } = activeProfile;
@@ -52,10 +47,7 @@ const Profile = ({ data, onReload, onLoadMore, isLastPage, onDeleteProfile }) =>
           title={`delete-${record.name}`}
           extraOnClick={() => {
             setActiveProfile({
-              id: record.id,
-              name: record.name,
-              profileType: record.profileType,
-              __typename: record.__typename,
+              ...record,
             });
           }}
           onSuccess={deleteProfile}

--- a/src/containers/Profile/tests/index.test.js
+++ b/src/containers/Profile/tests/index.test.js
@@ -93,7 +93,7 @@ describe('<Profile />', () => {
   });
 
   it('cancel button should hide delete modal', async () => {
-    const { getByText, getByRole } = render(
+    const { getByText, getByRole, queryByText } = render(
       <Router>
         <Profile {...mockProps} />
       </Router>
@@ -101,12 +101,11 @@ describe('<Profile />', () => {
 
     fireEvent.click(getByRole('button', { name: `delete-${mockProps.data[0].name}` }));
 
-    const paragraph = getByText(/Are you sure you want to delete the profile:/i);
-    expect(paragraph).toBeVisible();
+    expect(getByText(/Are you sure you want to delete the profile:/i)).toBeVisible();
 
     fireEvent.click(getByRole('button', { name: /cancel/i }));
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(queryByText(/Are you sure you want to delete the profile:/i)).not.toBeInTheDocument();
     });
   });
 

--- a/src/containers/ProfileDetails/components/AccessPoint/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/tests/index.test.js
@@ -734,7 +734,7 @@ describe('<AccessPoints />', () => {
       );
     };
 
-    const { getByText, getByRole, getByTestId } = render(<AccessPointComp />);
+    const { getByText, getByRole, getByTestId, queryByText } = render(<AccessPointComp />);
 
     fireEvent.click(getByTestId('addGre'));
     expect(getByText('Add GRE Configuration')).toBeVisible();
@@ -742,7 +742,7 @@ describe('<AccessPoints />', () => {
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Add GRE Configuration', { selector: 'div' })).not.toBeVisible();
+      expect(queryByText('Add GRE Configuration', { selector: 'div' })).not.toBeInTheDocument();
     });
   });
 
@@ -756,7 +756,9 @@ describe('<AccessPoints />', () => {
       );
     };
 
-    const { getByTestId, getByText, getByRole, getByLabelText } = render(<AccessPointComp />);
+    const { getByTestId, getByText, getByRole, getByLabelText, queryByText } = render(
+      <AccessPointComp />
+    );
     const testIp = '192.168.0.13';
 
     fireEvent.click(getByTestId('addGre'));
@@ -767,7 +769,7 @@ describe('<AccessPoints />', () => {
 
     fireEvent.click(getByRole('button', { name: /save/i }));
     await waitFor(() => {
-      expect(getByText('Add GRE Configuration')).not.toBeVisible();
+      expect(queryByText('Add GRE Configuration')).not.toBeInTheDocument();
       expect(getByText('gre2')).toBeVisible();
     });
   });

--- a/src/containers/ProfileDetails/components/CaptivePortal/components/Users/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/components/Users/tests/index.test.js
@@ -83,7 +83,7 @@ describe('<Users />', () => {
   });
 
   it('Cancel button press should hide Add User modal', async () => {
-    const { getByRole, getByText } = render(<Users {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<Users {...mockProps} />);
 
     fireEvent.click(getByRole('button', { name: /add user/i }));
 
@@ -91,24 +91,23 @@ describe('<Users />', () => {
     expect(paragraph).toBeVisible();
     fireEvent.click(getByRole('button', { name: `Cancel` }));
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(queryByText('Add User', { selector: 'div' })).not.toBeInTheDocument();
     });
   });
 
   it('Cancel button press should hide Edit User modal', async () => {
-    const { getByRole, getByText } = render(<Users {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<Users {...mockProps} />);
 
     fireEvent.click(getByRole('button', { name: `edit-${mockProps.userList[0].username}` }));
-    const paragraph = getByText('Edit User');
-    expect(paragraph).toBeVisible();
+    expect(getByText('Edit User')).toBeVisible();
     fireEvent.click(getByRole('button', { name: `Cancel` }));
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(queryByText('Edit User')).not.toBeInTheDocument();
     });
   });
 
   it('Cancel button press should hide Delete User modal', async () => {
-    const { getByRole, getByText } = render(<Users {...mockProps} />);
+    const { getByRole, getByText, queryByText } = render(<Users {...mockProps} />);
     fireEvent.click(getByRole('button', { name: `delete-${mockProps.userList[0].username}` }));
 
     const paragraph = getByText(/Are you sure you want to delete the user:/i);
@@ -117,7 +116,7 @@ describe('<Users />', () => {
 
     fireEvent.click(getByRole('button', { name: `Cancel` }));
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(queryByText(/Are you sure you want to delete the user:/i)).not.toBeInTheDocument();
     });
   });
 

--- a/src/containers/ProfileDetails/components/CaptivePortal/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/tests/index.test.js
@@ -1191,7 +1191,7 @@ describe('<CaptivePortalForm />', () => {
         </Form>
       );
     };
-    const { getByLabelText, getByText, getByRole } = render(<CaptivePortalFormComp />);
+    const { getByLabelText, getByText, getByRole, queryByText } = render(<CaptivePortalFormComp />);
 
     const authentication = getByLabelText('Authentication');
     fireEvent.keyDown(authentication, DOWN_ARROW);
@@ -1204,7 +1204,7 @@ describe('<CaptivePortalForm />', () => {
     expect(paragraph).toBeVisible();
     fireEvent.click(getByRole('button', { name: `Cancel` }));
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(queryByText('Add User', { selector: 'div' })).not.toBeInTheDocument();
     });
   });
 
@@ -1217,7 +1217,7 @@ describe('<CaptivePortalForm />', () => {
         </Form>
       );
     };
-    const { getByLabelText, getByText, getByRole } = render(<CaptivePortalFormComp />);
+    const { getByLabelText, getByText, getByRole, queryByText } = render(<CaptivePortalFormComp />);
 
     const authentication = getByLabelText('Authentication');
     fireEvent.keyDown(authentication, DOWN_ARROW);
@@ -1227,11 +1227,10 @@ describe('<CaptivePortalForm />', () => {
     fireEvent.click(
       getByRole('button', { name: `edit-${mockProps.details.userList[0].username}` })
     );
-    const paragraph = getByText('Edit User');
-    expect(paragraph).toBeVisible();
+    expect(getByText('Edit User')).toBeVisible();
     fireEvent.click(getByRole('button', { name: /Cancel/i }));
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(queryByText('Edit User')).not.toBeInTheDocument();
     });
   });
 
@@ -1244,7 +1243,7 @@ describe('<CaptivePortalForm />', () => {
         </Form>
       );
     };
-    const { getByLabelText, getByText, getByRole } = render(<CaptivePortalFormComp />);
+    const { getByLabelText, getByText, getByRole, queryByText } = render(<CaptivePortalFormComp />);
 
     const authentication = getByLabelText('Authentication');
     fireEvent.keyDown(authentication, DOWN_ARROW);
@@ -1261,7 +1260,7 @@ describe('<CaptivePortalForm />', () => {
 
     fireEvent.click(getByRole('button', { name: /Cancel/i }));
     await waitFor(() => {
-      expect(paragraph).not.toBeVisible();
+      expect(queryByText(/Are you sure you want to delete the user:/i)).not.toBeInTheDocument();
     });
   });
 

--- a/src/containers/ProfileDetails/components/Operator/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/Operator/tests/index.test.js
@@ -169,7 +169,7 @@ describe('<OperatorForm />', () => {
         </Form>
       );
     };
-    const { getByText, getByRole } = render(<OperatorFormComp />);
+    const { getByText, getByRole, queryByText } = render(<OperatorFormComp />);
 
     fireEvent.click(getByRole('button', { name: /add Name/i }));
 
@@ -178,7 +178,7 @@ describe('<OperatorForm />', () => {
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Add Operator Name', { selector: 'div' })).not.toBeVisible();
+      expect(queryByText('Add Operator Name', { selector: 'div' })).not.toBeInTheDocument();
     });
   });
 
@@ -191,7 +191,9 @@ describe('<OperatorForm />', () => {
         </Form>
       );
     };
-    const { getByText, getByRole, getByLabelText, getAllByText } = render(<OperatorFormComp />);
+    const { getByText, getByRole, getByLabelText, getAllByText, queryByText } = render(
+      <OperatorFormComp />
+    );
 
     fireEvent.click(getByRole('button', { name: /add Name/i }));
 
@@ -206,7 +208,7 @@ describe('<OperatorForm />', () => {
 
     fireEvent.click(getByRole('button', { name: 'Save' }));
     await waitFor(() => {
-      expect(getByText('Add Operator Name', { selector: 'div' })).not.toBeVisible();
+      expect(queryByText('Add Operator Name', { selector: 'div' })).not.toBeInTheDocument();
       expect(getByText('TestName')).toBeVisible();
     });
   });

--- a/src/containers/ProfileDetails/components/PasspointProfile/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/tests/index.test.js
@@ -528,7 +528,7 @@ describe('<PasspointProfileForm />', () => {
     fireEvent.click(getByRole('button', { name: /cancel/i }));
 
     await waitFor(() => {
-      expect(queryByText('Add Connection Capability')).not.toBeVisible();
+      expect(queryByText('Add Connection Capability')).not.toBeInTheDocument();
     });
   });
 

--- a/src/containers/ProfileDetails/components/ProviderId/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/ProviderId/tests/index.test.js
@@ -92,7 +92,9 @@ describe('<ProviderIdForm />', () => {
         </Form>
       );
     };
-    const { getByRole, getByText, getByLabelText, getByTestId } = render(<ProviderIdFormComp />);
+    const { getByRole, getByText, getByLabelText, getByTestId, queryByText } = render(
+      <ProviderIdFormComp />
+    );
 
     fireEvent.click(getByTestId('addPlmn'));
     expect(getByText('Add Public Land Mobile Network (PLMN)')).toBeVisible();
@@ -104,7 +106,7 @@ describe('<ProviderIdForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('Add Public Land Mobile Network (PLMN)')).not.toBeVisible();
+      expect(queryByText('Add Public Land Mobile Network (PLMN)')).not.toBeInTheDocument();
       expect(getByText('240')).toBeVisible();
       expect(getByText('680')).toBeVisible();
     });
@@ -145,14 +147,14 @@ describe('<ProviderIdForm />', () => {
         </Form>
       );
     };
-    const { getByText, getByTestId, getByRole } = render(<ProviderIdFormComp />);
+    const { getByText, getByTestId, getByRole, queryByText } = render(<ProviderIdFormComp />);
 
     fireEvent.click(getByTestId('addEapMethod'));
     expect(getByText('Add EAP Method')).toBeVisible();
 
     fireEvent.click(getByRole('button', { name: /cancel/i }));
     await waitFor(() => {
-      expect(getByText('Add EAP Method')).not.toBeVisible();
+      expect(queryByText('Add EAP Method')).not.toBeInTheDocument();
     });
   });
 
@@ -165,7 +167,7 @@ describe('<ProviderIdForm />', () => {
         </Form>
       );
     };
-    const { getByTestId, getByText, getByRole } = render(<ProviderIdFormComp />);
+    const { getByTestId, getByText, getByRole, queryByText } = render(<ProviderIdFormComp />);
 
     fireEvent.click(getByTestId('addPlmn'));
     expect(getByText('Add Public Land Mobile Network (PLMN)')).toBeVisible();
@@ -175,7 +177,7 @@ describe('<ProviderIdForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('Add Public Land Mobile Network (PLMN)')).not.toBeVisible();
+      expect(queryByText('Add Public Land Mobile Network (PLMN)')).not.toBeInTheDocument();
     });
   });
 
@@ -469,7 +471,7 @@ describe('<ProviderIdForm />', () => {
         </Form>
       );
     };
-    const { getByText, getByTestId, getByRole } = render(<ProviderIdFormComp />);
+    const { getByText, getByTestId, getByRole, queryByText } = render(<ProviderIdFormComp />);
 
     expect(getByText('Enabled')); // The switch is enabled
 
@@ -480,7 +482,7 @@ describe('<ProviderIdForm />', () => {
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Add Name', { selector: 'div' })).not.toBeVisible();
+      expect(queryByText('Add Name', { selector: 'div' })).not.toBeInTheDocument();
     });
   });
 
@@ -498,7 +500,7 @@ describe('<ProviderIdForm />', () => {
         </Form>
       );
     };
-    const { getByText, getByTestId, getByRole } = render(<ProviderIdFormComp />);
+    const { getByText, getByTestId, getByRole, queryByText } = render(<ProviderIdFormComp />);
 
     expect(getByText('Enabled')); // The switch is enabled
 
@@ -509,7 +511,7 @@ describe('<ProviderIdForm />', () => {
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Add Description', { selector: 'div' })).not.toBeVisible();
+      expect(queryByText('Add Description', { selector: 'div' })).not.toBeInTheDocument();
     });
   });
 
@@ -527,7 +529,7 @@ describe('<ProviderIdForm />', () => {
         </Form>
       );
     };
-    const { getByText, getByTestId, getByRole } = render(<ProviderIdFormComp />);
+    const { getByText, getByTestId, getByRole, queryByText } = render(<ProviderIdFormComp />);
 
     expect(getByText('Enabled')); // The switch is enabled
 
@@ -538,7 +540,7 @@ describe('<ProviderIdForm />', () => {
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Add Icon', { selector: 'div' })).not.toBeVisible();
+      expect(queryByText('Add Icon', { selector: 'div' })).not.toBeInTheDocument();
     });
   });
 

--- a/src/containers/ProfileDetails/components/Venue/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/Venue/tests/index.test.js
@@ -145,15 +145,13 @@ describe('<VenueForm />', () => {
         </Form>
       );
     };
-    const { getByText, getByRole, getByLabelText } = render(<VenueFormComp />);
+    const { getByText, getByRole, queryByLabelText } = render(<VenueFormComp />);
     fireEvent.click(getByRole('button', { name: 'Add Name' }));
     expect(getByText('Add Name')).toBeVisible();
 
     fireEvent.click(getByRole('button', { name: /cancel/i }));
     await waitFor(() => {
-      expect(getByLabelText('Name')).not.toBeVisible();
-      expect(getByLabelText('Locale')).not.toBeVisible();
-      expect(getByLabelText('Url')).not.toBeVisible();
+      expect(queryByLabelText('Add Name')).not.toBeInTheDocument();
     });
   });
 

--- a/src/containers/ProfileDetails/tests/index.test.js
+++ b/src/containers/ProfileDetails/tests/index.test.js
@@ -682,7 +682,7 @@ describe('<ProfileDetails />', () => {
   });
 
   it('Cancel button click should hide confirmation modal', async () => {
-    const { getByRole, getByText, getByLabelText } = render(
+    const { getByRole, getByText, getByLabelText, queryByText } = render(
       <Router>
         <ProfileDetails {...mockProps} />
       </Router>
@@ -693,7 +693,7 @@ describe('<ProfileDetails />', () => {
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(getByText('Leave Form?')).not.toBeVisible();
+      expect(queryByText('Leave Form?')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
JIRA: [ID](LINK)

## Description
*Summary of this PR*

Added `destroyOnClose` prop so that  child components and state logic are removed on modal close to improve performance. 

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*