### PR TITLE
bugfix/WIFI-824: File previewing fix for Captive-Portal profile

### DIFF
--- a/src/containers/Manufacturer/index.js
+++ b/src/containers/Manufacturer/index.js
@@ -40,7 +40,7 @@ const Manufacturer = ({ onSearchOUI, onUpdateOUI, returnedOUI, fileUpload, loadi
 
     const validSize = file.size / 1024 / 1024 < 5;
     if (!validSize) {
-      if (showMessages) message.error('File must smaller than 5MB!');
+      if (showMessages) message.error('File must be smaller than 5MB!');
       return false;
     }
 

--- a/src/containers/ProfileDetails/components/PasspointProfile/index.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/index.js
@@ -129,14 +129,14 @@ const PasspointProfileForm = ({
     const isJpgOrPng =
       file.type === 'image/jpeg' || file.type === 'image/png' || file.type === 'image/jpg';
     if (!isJpgOrPng) {
-      if (showMessages) message.error('You can only upload JPG/PNG file!');
+      if (showMessages) message.error('You can only upload a JPG/PNG file!');
       return false;
     }
 
     const isValidSize = file.size / 1024 < 400;
 
     if (!isValidSize) {
-      if (showMessages) message.error('Image must smaller than 400KB!');
+      if (showMessages) message.error('Image must be smaller than 400KB!');
       return false;
     }
 

--- a/src/containers/ProfileDetails/components/PasspointProfile/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/tests/index.test.js
@@ -426,7 +426,7 @@ describe('<PasspointProfileForm />', () => {
     });
 
     fireEvent.change(getByTestId('termsAndConditionsUpload'), { target: { files: [gifFile] } });
-    expect(getByText('You can only upload JPG/PNG file!')).toBeVisible();
+    expect(getByText('You can only upload a JPG/PNG file!')).toBeVisible();
   });
 
   it('uploading a termsAndConditionsFile in png format should add image on screen', () => {

--- a/src/containers/ProfileDetails/index.js
+++ b/src/containers/ProfileDetails/index.js
@@ -54,6 +54,7 @@ const ProfileDetails = ({
   operatorProfiles,
   idProviderProfiles,
   fileUpload,
+  onDownloadFile,
   extraButtons,
   onSearchProfile,
   onFetchMoreProfiles,
@@ -283,6 +284,7 @@ const ProfileDetails = ({
             details={details}
             childProfiles={childProfiles}
             fileUpload={fileUpload}
+            onDownloadFile={onDownloadFile}
             radiusProfiles={radiusProfiles}
             onSearchProfile={onSearchProfile}
             onFetchMoreProfiles={onFetchMoreProfiles}
@@ -324,6 +326,7 @@ const ProfileDetails = ({
 ProfileDetails.propTypes = {
   onUpdateProfile: PropTypes.func.isRequired,
   fileUpload: PropTypes.func.isRequired,
+  onDownloadFile: PropTypes.func.isRequired,
   name: PropTypes.string,
   profileType: PropTypes.string,
   details: PropTypes.instanceOf(Object),


### PR DESCRIPTION
JIRA: [WIFI-824](https://telecominfraproject.atlassian.net/browse/WIFI-824)

## Description
*Summary of this PR*
Fixed issue where uploaded background/logo image on Captive Portal profile could not be previewed
- Added preview modal
- Changed file upload from a File object to a base64 string of the file

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/110366779-bf2c8800-8014-11eb-850a-0e8826088074.png)


### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/110366801-c8b5f000-8014-11eb-9424-e302042e48b1.png)
![image](https://user-images.githubusercontent.com/55258316/110366997-1af71100-8015-11eb-8361-afd859c9078b.png)

