### PR TITLE
bugfix/WIFI-1487: Changed default MIMO mode value from 2x2 to auto

### DIFF
--- a/src/containers/ProfileDetails/components/constants.js
+++ b/src/containers/ProfileDetails/components/constants.js
@@ -8,7 +8,7 @@ const defaultRfProfile = {
     forceScanDuringVoice: 'disabled',
     rtsCtsThreshold: 65535,
     channelBandwidth: 'is80MHz',
-    mimoMode: 'twoByTwo',
+    mimoMode: 'none',
     maxNumClients: 100,
     autoChannelSelection: false,
     activeScanSettings: {
@@ -55,7 +55,7 @@ const defaultRfProfile = {
     forceScanDuringVoice: 'disabled',
     rtsCtsThreshold: 65535,
     channelBandwidth: 'is20MHz',
-    mimoMode: 'twoByTwo',
+    mimoMode: 'none',
     maxNumClients: 100,
     autoChannelSelection: false,
     activeScanSettings: {
@@ -102,7 +102,7 @@ const defaultRfProfile = {
     forceScanDuringVoice: 'disabled',
     rtsCtsThreshold: 65535,
     channelBandwidth: 'is80MHz',
-    mimoMode: 'twoByTwo',
+    mimoMode: 'none',
     maxNumClients: 100,
     autoChannelSelection: false,
     activeScanSettings: {
@@ -149,7 +149,7 @@ const defaultRfProfile = {
     forceScanDuringVoice: 'disabled',
     rtsCtsThreshold: 65535,
     channelBandwidth: 'is80MHz',
-    mimoMode: 'twoByTwo',
+    mimoMode: 'none',
     maxNumClients: 100,
     autoChannelSelection: false,
     activeScanSettings: {


### PR DESCRIPTION
JIRA: [WIFI-1487](https://telecominfraproject.atlassian.net/browse/WIFI-1847)

## Description
*Summary of this PR*
Changed default MIMO mode value from 2x2 to auto

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*