### PR TITLE
feature/NETEXP-565: Disable reboot btn when firmware upgrade in progress

### DIFF
--- a/src/containers/AccessPointDetails/components/Firmware/index.js
+++ b/src/containers/AccessPointDetails/components/Firmware/index.js
@@ -90,6 +90,21 @@ const Firmware = ({
 
   const status = data?.status?.firmware?.detailsJSON || {};
 
+  const getRebootStatus = () => {
+    switch (status?.upgradeState) {
+      case 'download_initiated':
+      case 'downloading':
+      case 'apply_initiated':
+      case 'applying':
+      case 'reboot_initiated':
+      case 'rebooting':
+        return true;
+
+      default:
+        return false;
+    }
+  };
+
   if (loadingFirmware) {
     return <Loading data-testid="loadingFirmware" />;
   }
@@ -121,7 +136,7 @@ const Firmware = ({
             className={styles.saveButton}
             onClick={handleOnReboot}
             name="reboot"
-            disabled={status.upgradeState !== 'undefined'}
+            disabled={getRebootStatus()}
           >
             Reboot AP
           </Button>

--- a/src/containers/AccessPointDetails/components/Firmware/index.js
+++ b/src/containers/AccessPointDetails/components/Firmware/index.js
@@ -117,7 +117,12 @@ const Firmware = ({
       />
       <Form {...pageLayout} form={form} onValuesChange={handleOnFormChange}>
         <div className={styles.InlineEndDiv}>
-          <Button className={styles.saveButton} onClick={handleOnReboot} name="reboot">
+          <Button
+            className={styles.saveButton}
+            onClick={handleOnReboot}
+            name="reboot"
+            disabled={status.upgradeState !== 'undefined'}
+          >
             Reboot AP
           </Button>
         </div>


### PR DESCRIPTION
JIRA: [NETEXP-565](https://connectustechnologies.atlassian.net/jira/software/c/projects/NETEXP/issues/NETEXP-565?filter=myopenissues)

## Description
*Summary of this PR*
Disabled upgrade button when firmware upgrade is in progress
- status.upgradeState value is "undefined" when there is no upgrade in progress
- The reboot button is now disabled when the value is not "undefined"

Update Mar 19:
- Added more options that determine whether reboot button is disabled

Might have found a bug in the api:
When clicking upgrade firmware button on an ap, the response is successful:

   `data :{
     updateEquipmentFirmware: {
      success: true,
      __typename: "GenericResponse"
     }
   }`

But the `status.upgradeState` remains the same 'undefined' even when refetching the data. 