### PR TITLE
bugfix/NETEXP-1295: Fixed OS stats chart units

### DIFF
--- a/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
+++ b/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
@@ -125,7 +125,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
             color: '#34AE29',
           }}
         >
-          Free Memory (MB)
+          Free Memory
         </YAxis.Title>
         <SplineSeries id="freeMemory" name="Free Memory" data={freeMemory} color="#34AE29" />
       </YAxis>

--- a/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
+++ b/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
@@ -11,7 +11,12 @@ import {
   SplineSeries,
   Tooltip,
 } from 'react-jsx-highstock';
-import { formatBytes, labelFormatter } from 'utils/bytes';
+import {
+  formatBytes,
+  bytesLabelFormatter,
+  percentageLabelFormatter,
+  celsiusLabelFormatter,
+} from 'utils/formatFunctions';
 
 import Loading from 'components/Loading';
 
@@ -88,6 +93,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
         id="usage"
         labels={{
           style: { color: '#7cb5ec' },
+          formatter: percentageLabelFormatter,
         }}
         visible={visible}
         showEmpty={false}
@@ -97,7 +103,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
             color: '#7cb5ec',
           }}
         >
-          CPU Utilization (%)
+          CPU Utilization
         </YAxis.Title>
         {Object.keys(cpuUsage).map(i => (
           <SplineSeries
@@ -114,7 +120,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
         id="free"
         labels={{
           style: { color: '#34AE29' },
-          formatter: labelFormatter,
+          formatter: bytesLabelFormatter,
         }}
         opposite
         visible={visible}
@@ -134,6 +140,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
         id="temp"
         labels={{
           style: { color: '#f7a35c' },
+          formatter: celsiusLabelFormatter,
         }}
         visible={visible}
         showEmpty={false}
@@ -143,7 +150,7 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
             color: '#f7a35c',
           }}
         >
-          CPU Temperature (°C)
+          CPU Temperature
         </YAxis.Title>
         <SplineSeries id="cpuTemp" name="CPU Temperature" data={cpuTemp} color="#f7a35c" />
       </YAxis>

--- a/src/containers/ClientDeviceDetails/components/DeviceDetailCard/index.js
+++ b/src/containers/ClientDeviceDetails/components/DeviceDetailCard/index.js
@@ -3,7 +3,7 @@ import { WifiOutlined, SwapOutlined, SignalFilled } from '@ant-design/icons';
 import PropTypes from 'prop-types';
 import { Card } from 'antd';
 
-import { formatBytes } from 'utils/bytes';
+import { formatBytes } from 'utils/formatFunctions';
 import styles from './index.module.scss';
 
 const DeviceDetailCard = ({

--- a/src/containers/ClientDeviceDetails/index.js
+++ b/src/containers/ClientDeviceDetails/index.js
@@ -5,7 +5,7 @@ import { Card, Alert } from 'antd';
 import { LeftOutlined, ReloadOutlined } from '@ant-design/icons';
 import moment from 'moment';
 
-import { formatBytes, formatBitsPerSecond } from 'utils/bytes';
+import { formatBytes, formatBitsPerSecond } from 'utils/formatFunctions';
 import Button from 'components/Button';
 import DeviceHistory from 'components/DeviceHistory';
 import ThemeContext from 'contexts/ThemeContext';

--- a/src/utils/bytes.js
+++ b/src/utils/bytes.js
@@ -14,7 +14,7 @@ export function formatBytes(bytes, decimals = 2) {
 }
 
 export function labelFormatter() {
-  return formatBytes(this.value).replace(/[^\d.-]/g, '');
+  return formatBytes(this.value);
 }
 
 export function formatBitsPerSecond(bps) {

--- a/src/utils/formatFunctions.js
+++ b/src/utils/formatFunctions.js
@@ -13,7 +13,7 @@ export function formatBytes(bytes, decimals = 2) {
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
 }
 
-export function labelFormatter() {
+export function bytesLabelFormatter() {
   return formatBytes(this.value);
 }
 
@@ -29,4 +29,20 @@ export function formatBitsPerSecond(bps) {
   }
 
   return `${Math.floor(bps)} bps`;
+}
+
+function formatCelcius(celsius) {
+  return `${Math.round(celsius * 100) / 100} °C`;
+}
+
+export function celsiusLabelFormatter() {
+  return formatCelcius(this.value);
+}
+
+function formatPercentage(percentage) {
+  return `${Math.round(percentage * 100) / 100} %`;
+}
+
+export function percentageLabelFormatter() {
+  return formatPercentage(this.value);
 }


### PR DESCRIPTION
JIRA: [NETEXP-1295](https://connectustechnologies.atlassian.net/browse/NETEXP-1295)

## Description
*Summary of this PR*
- Removed units from all y-axis labels and added them to respective y-axis values

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/111684195-c6197e80-87fc-11eb-98bf-a93059172a24.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/111708942-23bdc300-881d-11eb-8cb5-a295c3ac48c2.png)
