### PR TITLE
bugfix/NETEXP-1335: Passpoint profile childProfileIds fix

### DIFF
--- a/src/containers/AddProfile/index.js
+++ b/src/containers/AddProfile/index.js
@@ -143,14 +143,14 @@ const AddProfile = ({
         }
 
         if (profileType === PROFILES.passpoint) {
-          if (!values.passpointVenueProfileId) {
+          if (!values.passpointVenueProfileId?.value) {
             notification.error({
               message: 'Error',
               description: 'A Venue Profile is required.',
             });
             return;
           }
-          if (!values.passpointOperatorProfileId) {
+          if (!values.passpointOperatorProfileId?.value) {
             notification.error({
               message: 'Error',
               description: 'A Operator Profile is required.',
@@ -164,8 +164,14 @@ const AddProfile = ({
             });
             return;
           }
+          if (!values.osuSsidProfileId) {
+            notification.error({
+              message: 'Error',
+              description: 'An SSID Profile is required.',
+            });
+            return;
+          }
 
-          values.associatedAccessSsidProfileIds.forEach(i => formattedData.childProfileIds.push(i));
           formattedData.model_type = 'PasspointProfile';
           formattedData = Object.assign(
             formattedData,

--- a/src/containers/ProfileDetails/components/PasspointProfile/index.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/index.js
@@ -29,6 +29,7 @@ const PasspointProfileForm = ({
   ssidProfiles,
   childProfiles,
   idProviderProfiles,
+  associatedSsidProfiles,
   fileUpload,
   onSearchProfile,
   onFetchMoreProfiles,
@@ -48,7 +49,7 @@ const PasspointProfileForm = ({
   );
 
   const [selectedChildSsids, setSelectedChildSsids] = useState(
-    childProfiles.filter(
+    associatedSsidProfiles.filter(
       i => i.profileType === 'ssid' && i.id !== details?.osuSsidProfileId?.toString()
     ) || []
   );
@@ -58,7 +59,9 @@ const PasspointProfileForm = ({
   );
 
   useEffect(() => {
-    const selectedSsid = childProfiles?.find(o => o.id === details?.osuSsidProfileId?.toString());
+    const selectedSsid = associatedSsidProfiles?.find(
+      o => o.id === details?.osuSsidProfileId?.toString()
+    );
     const selectedVenue = childProfiles?.find(
       o => o.id === details?.passpointVenueProfileId?.toString()
     );
@@ -89,12 +92,7 @@ const PasspointProfileForm = ({
           key: i?.id || [],
           label: i?.name || [],
         })) || [],
-      osuSsidProfileId:
-        {
-          value: selectedSsid?.id || null,
-          key: selectedSsid?.id || null,
-          label: selectedSsid?.name || null,
-        } || null,
+      osuSsidProfileId: selectedSsid?.id,
       enableInterworkingAndHs20: details?.enableInterworkingAndHs20 ? 'true' : 'false',
       hessid: {
         addressAsString: details?.hessid?.addressAsString || null,
@@ -344,7 +342,6 @@ const PasspointProfileForm = ({
             onSearch={name => onSearchProfile(name, PROFILES.ssid)}
             loading={loadingSSIDProfiles}
             notFoundContent={!loadingSSIDProfiles && <Empty />}
-            labelInValue
           >
             {ssidProfiles.map(i => (
               <Option key={i.id} value={i.id}>
@@ -567,6 +564,7 @@ PasspointProfileForm.propTypes = {
   ssidProfiles: PropTypes.instanceOf(Array),
   childProfiles: PropTypes.instanceOf(Array),
   idProviderProfiles: PropTypes.instanceOf(Array),
+  associatedSsidProfiles: PropTypes.instanceOf(Array),
   fileUpload: PropTypes.func,
   onSearchProfile: PropTypes.func,
   onFetchMoreProfiles: PropTypes.func,
@@ -585,6 +583,7 @@ PasspointProfileForm.defaultProps = {
   ssidProfiles: [],
   childProfiles: [],
   idProviderProfiles: [],
+  associatedSsidProfiles: [],
   fileUpload: () => {},
   onSearchProfile: null,
   onFetchMoreProfiles: () => {},

--- a/src/containers/ProfileDetails/components/PasspointProfile/index.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/index.js
@@ -30,6 +30,7 @@ const PasspointProfileForm = ({
   childProfiles,
   idProviderProfiles,
   associatedSsidProfiles,
+  osuSsidProfile,
   fileUpload,
   onSearchProfile,
   onFetchMoreProfiles,
@@ -89,7 +90,12 @@ const PasspointProfileForm = ({
           key: i?.id || [],
           label: i?.name || [],
         })) || [],
-      osuSsidProfileId: details?.osuSsidProfileId?.toString(),
+      osuSsidProfileId:
+        {
+          value: osuSsidProfile?.id || null,
+          key: osuSsidProfile?.id || null,
+          label: osuSsidProfile?.name || null,
+        } || null,
       enableInterworkingAndHs20: details?.enableInterworkingAndHs20 ? 'true' : 'false',
       hessid: {
         addressAsString: details?.hessid?.addressAsString || null,
@@ -339,6 +345,7 @@ const PasspointProfileForm = ({
             onSearch={name => onSearchProfile(name, PROFILES.ssid)}
             loading={loadingSSIDProfiles}
             notFoundContent={!loadingSSIDProfiles && <Empty />}
+            labelInValue
           >
             {ssidProfiles.map(i => (
               <Option key={i.id} value={i.id}>
@@ -562,6 +569,7 @@ PasspointProfileForm.propTypes = {
   childProfiles: PropTypes.instanceOf(Array),
   idProviderProfiles: PropTypes.instanceOf(Array),
   associatedSsidProfiles: PropTypes.instanceOf(Array),
+  osuSsidProfile: PropTypes.instanceOf(Object),
   fileUpload: PropTypes.func,
   onSearchProfile: PropTypes.func,
   onFetchMoreProfiles: PropTypes.func,
@@ -581,6 +589,7 @@ PasspointProfileForm.defaultProps = {
   childProfiles: [],
   idProviderProfiles: [],
   associatedSsidProfiles: [],
+  osuSsidProfile: {},
   fileUpload: () => {},
   onSearchProfile: null,
   onFetchMoreProfiles: () => {},

--- a/src/containers/ProfileDetails/components/PasspointProfile/index.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/index.js
@@ -59,9 +59,6 @@ const PasspointProfileForm = ({
   );
 
   useEffect(() => {
-    const selectedSsid = associatedSsidProfiles?.find(
-      o => o.id === details?.osuSsidProfileId?.toString()
-    );
     const selectedVenue = childProfiles?.find(
       o => o.id === details?.passpointVenueProfileId?.toString()
     );
@@ -92,7 +89,7 @@ const PasspointProfileForm = ({
           key: i?.id || [],
           label: i?.name || [],
         })) || [],
-      osuSsidProfileId: selectedSsid?.id,
+      osuSsidProfileId: details?.osuSsidProfileId?.toString(),
       enableInterworkingAndHs20: details?.enableInterworkingAndHs20 ? 'true' : 'false',
       hessid: {
         addressAsString: details?.hessid?.addressAsString || null,

--- a/src/containers/ProfileDetails/components/PasspointProfile/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/tests/index.test.js
@@ -52,14 +52,8 @@ const mockProps = {
     termsAndConditionsFile: null,
     unauthenticatedEmergencyServiceAccessible: false,
   },
-  childProfileIds: ['40', '30', '20', '10'],
+  childProfileIds: ['30', '20', '10'],
   childProfiles: [
-    {
-      id: '40',
-      name: 'ssid-profile-1',
-      profileType: 'ssid',
-      details: {},
-    },
     {
       id: '30',
       name: 'Venue-Profile',
@@ -76,6 +70,14 @@ const mockProps = {
       id: '10',
       name: 'Operator-Profile',
       profileType: 'passpoint_operator',
+      details: {},
+    },
+  ],
+  associatedSsidProfiles: [
+    {
+      id: '40',
+      name: 'ssid-profile-1',
+      profileType: 'ssid',
       details: {},
     },
   ],

--- a/src/containers/ProfileDetails/index.js
+++ b/src/containers/ProfileDetails/index.js
@@ -53,6 +53,7 @@ const ProfileDetails = ({
   venueProfiles,
   operatorProfiles,
   idProviderProfiles,
+  associatedSsidProfiles,
   fileUpload,
   onDownloadFile,
   extraButtons,
@@ -154,14 +155,14 @@ const ProfileDetails = ({
         }
 
         if (profileType === PROFILES.passpoint) {
-          if (!values.passpointVenueProfileId) {
+          if (!values.passpointVenueProfileId?.value) {
             notification.error({
               message: 'Error',
               description: 'A Venue Profile is required.',
             });
             return;
           }
-          if (!values.passpointOperatorProfileId) {
+          if (!values.passpointOperatorProfileId?.value) {
             notification.error({
               message: 'Error',
               description: 'A Operator Profile is required.',
@@ -182,7 +183,6 @@ const ProfileDetails = ({
             });
             return;
           }
-          values.associatedAccessSsidProfileIds.forEach(i => formattedData.childProfileIds.push(i));
           formattedData.model_type = 'PasspointProfile';
           formattedData = Object.assign(formattedData, formatPasspointForm(values, details));
         }
@@ -306,6 +306,7 @@ const ProfileDetails = ({
             venueProfiles={venueProfiles}
             operatorProfiles={operatorProfiles}
             idProviderProfiles={idProviderProfiles}
+            associatedSsidProfiles={associatedSsidProfiles}
             fileUpload={fileUpload}
             onSearchProfile={onSearchProfile}
             onFetchMoreProfiles={onFetchMoreProfiles}
@@ -346,6 +347,7 @@ ProfileDetails.propTypes = {
   idProviderProfiles: PropTypes.instanceOf(Array),
   childProfiles: PropTypes.instanceOf(Array),
   childProfileIds: PropTypes.instanceOf(Array),
+  associatedSsidProfiles: PropTypes.instanceOf(Array),
   extraButtons: PropTypes.node,
   onSearchProfile: PropTypes.func,
   onFetchMoreProfiles: PropTypes.func,
@@ -372,6 +374,7 @@ ProfileDetails.defaultProps = {
   idProviderProfiles: [],
   childProfileIds: [],
   childProfiles: [],
+  associatedSsidProfiles: [],
   extraButtons: null,
   onSearchProfile: null,
   onFetchMoreProfiles: () => {},

--- a/src/containers/ProfileDetails/index.js
+++ b/src/containers/ProfileDetails/index.js
@@ -54,6 +54,7 @@ const ProfileDetails = ({
   operatorProfiles,
   idProviderProfiles,
   associatedSsidProfiles,
+  osuSsidProfile,
   fileUpload,
   onDownloadFile,
   extraButtons,
@@ -307,6 +308,7 @@ const ProfileDetails = ({
             operatorProfiles={operatorProfiles}
             idProviderProfiles={idProviderProfiles}
             associatedSsidProfiles={associatedSsidProfiles}
+            osuSsidProfile={osuSsidProfile}
             fileUpload={fileUpload}
             onSearchProfile={onSearchProfile}
             onFetchMoreProfiles={onFetchMoreProfiles}
@@ -348,6 +350,7 @@ ProfileDetails.propTypes = {
   childProfiles: PropTypes.instanceOf(Array),
   childProfileIds: PropTypes.instanceOf(Array),
   associatedSsidProfiles: PropTypes.instanceOf(Array),
+  osuSsidProfile: PropTypes.instanceOf(Object),
   extraButtons: PropTypes.node,
   onSearchProfile: PropTypes.func,
   onFetchMoreProfiles: PropTypes.func,
@@ -375,6 +378,7 @@ ProfileDetails.defaultProps = {
   childProfileIds: [],
   childProfiles: [],
   associatedSsidProfiles: [],
+  osuSsidProfile: {},
   extraButtons: null,
   onSearchProfile: null,
   onFetchMoreProfiles: () => {},

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -7,6 +7,13 @@ import {
 
 const isBool = value => value === 'true';
 
+const getFileType = type => {
+  if (type.startsWith('image/')) {
+    return type === 'image/png' ? 'PNG' : 'JPG';
+  }
+  return type;
+};
+
 export const formatSsidProfileForm = values => {
   const formattedData = {
     radioBasedConfigs: {},
@@ -141,13 +148,6 @@ export const formatRadiusForm = values => {
 export const formatCaptiveForm = (values, details) => {
   const formattedData = { ...values };
 
-  const getFileType = type => {
-    if (type.startsWith('image/')) {
-      return type === 'image/png' ? 'PNG' : 'JPG';
-    }
-    return type;
-  };
-
   if (
     !values.logoFile ||
     (values.logoFile && values.logoFile.fileList && values.logoFile.fileList.length === 0)
@@ -216,19 +216,7 @@ export const formatRfProfileForm = values => {
 export const formatPasspointForm = (values, details) => {
   const formattedData = { ...values };
 
-  const getFileType = type => {
-    if (type.startsWith('image/')) {
-      return type === 'image/png' ? 'PNG' : 'JPG';
-    }
-    return type;
-  };
-
-  if (typeof values?.osuSsidProfileId === 'object') {
-    formattedData.osuSsidProfileId = values?.osuSsidProfileId?.value;
-    formattedData.childProfileIds.push(formattedData.osuSsidProfileId);
-  } else {
-    formattedData.childProfileIds.push(values?.osuSsidProfileId);
-  }
+  formattedData.osuSsidProfileId = values?.osuSsidProfileId;
 
   if (typeof values?.passpointVenueProfileId === 'object') {
     formattedData.passpointVenueProfileId = values?.passpointVenueProfileId?.value;

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -216,7 +216,7 @@ export const formatRfProfileForm = values => {
 export const formatPasspointForm = (values, details) => {
   const formattedData = { ...values };
 
-  formattedData.osuSsidProfileId = values?.osuSsidProfileId;
+  formattedData.osuSsidProfileId = values?.osuSsidProfileId?.value;
 
   if (typeof values?.passpointVenueProfileId === 'object') {
     formattedData.passpointVenueProfileId = values?.passpointVenueProfileId?.value;


### PR DESCRIPTION
JIRA: [NETEXP-1335](https://connectustechnologies.atlassian.net/browse/NETEXP-1335)

## Description
*Summary of this PR*
Fixed passpoint point profile creation and update:  Update all associated SSIDs profiles by putting the Passpoint profile ID in the `childrenIds` instead of passing in SSID profile as `childrenIds` of Passpoint profile itself
