### PR TITLE
bugfix/WIFI-1880: Fixed CP splash page content saving bug

### DIFF
--- a/src/containers/ProfileDetails/components/CaptivePortal/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/index.js
@@ -606,16 +606,20 @@ const CaptivePortalForm = ({
                 Login Success Text
               </Button>
             </div>
-            {!isLoginText && (
-              <Item name="userAcceptancePolicy">
-                <TextArea data-testid="bodyContent" className={globalStyles.field} rows={4} />
-              </Item>
-            )}
-            {isLoginText && (
-              <Item name="successPageMarkdownText">
-                <TextArea data-testid="bodyContent" className={globalStyles.field} rows={4} />
-              </Item>
-            )}
+            <Item name="userAcceptancePolicy" hidden={isLoginText}>
+              <TextArea
+                data-testid="userAcceptancePolicy"
+                className={globalStyles.field}
+                rows={4}
+              />
+            </Item>
+            <Item name="successPageMarkdownText" hidden={!isLoginText}>
+              <TextArea
+                data-testid="successPageMarkdownText"
+                className={globalStyles.field}
+                rows={4}
+              />
+            </Item>
             &nbsp; Markdown and plain text supported.
           </Item>
         </Panel>

--- a/src/containers/ProfileDetails/components/CaptivePortal/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/tests/index.test.js
@@ -345,14 +345,14 @@ describe('<CaptivePortalForm />', () => {
         name: /login success text/i,
       })
     );
-    expect(getByTestId('bodyContent')).toHaveDisplayValue('Welcome to the network');
+    expect(getByTestId('successPageMarkdownText')).toHaveDisplayValue('Welcome to the network');
 
     fireEvent.click(
       getByRole('button', {
         name: /user acceptance policy text/i,
       })
     );
-    expect(getByTestId('bodyContent')).toHaveDisplayValue(
+    expect(getByTestId('userAcceptancePolicy')).toHaveDisplayValue(
       'Use this network at your own risk. No warranty of any kind.'
     );
   });


### PR DESCRIPTION
JIRA: [WIFI-1880](https://telecominfraproject.atlassian.net/browse/WIFI-1880)

## Description
*Summary of this PR*

Fixed bug on Captive Portal Page that prevented one of `userAcceptancePolicy` or `successPageMarkdownText` field  from being saved when both of them were changed (depends on order of edit, only the last field value was saved).
Reason for bug: Due to conditionally rendering the `userAcceptancePolicy` or `successPageMarkdownText` fields, the form destroyed the other form value and did not persist its value.
Solution: Instead of conditionally rendering them, hide the required field when not needed. 

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*