### PR TITLE
bugfix/WIFI-1895: Fixed Radius select bug on SSID profile

### DIFF
--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -50,6 +50,9 @@ const SSIDForm = ({
       });
     });
 
+    const radiusProfile =
+      childProfiles.find(profile => profile?.profileType === PROFILES.radius) ?? {};
+
     form.setFieldsValue({
       ssid: details?.ssid || '',
       bandwidthLimitDown: details?.bandwidthLimitDown || defaultSsidProfile.bandwidthLimitDown,
@@ -67,8 +70,8 @@ const SSIDForm = ({
       wepDefaultKeyId: details?.wepConfig?.primaryTxKeyId || 1,
       vlanId: details.vlanId || defaultSsidProfile.vlanId,
       radiusServiceId: {
-        value: childProfiles?.[0]?.id || null,
-        label: childProfiles?.[0]?.name || null,
+        value: radiusProfile.id ?? null,
+        label: radiusProfile.name ?? null,
       },
       ...radioBasedValues,
       childProfileIds: [],

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -50,8 +50,7 @@ const SSIDForm = ({
       });
     });
 
-    const radiusProfile =
-      childProfiles.find(profile => profile?.profileType === PROFILES.radius) ?? {};
+    const radiusProfile = childProfiles.find(profile => profile?.profileType === PROFILES.radius);
 
     form.setFieldsValue({
       ssid: details?.ssid || '',
@@ -70,8 +69,8 @@ const SSIDForm = ({
       wepDefaultKeyId: details?.wepConfig?.primaryTxKeyId || 1,
       vlanId: details.vlanId || defaultSsidProfile.vlanId,
       radiusServiceId: {
-        value: radiusProfile.id ?? null,
-        label: radiusProfile.name ?? null,
+        value: radiusProfile?.id || null,
+        label: radiusProfile?.name || null,
       },
       ...radioBasedValues,
       childProfileIds: [],


### PR DESCRIPTION
JIRA: [WIFI-1895](https://telecominfraproject.atlassian.net/browse/WIFI-1895)

## Description
*Summary of this PR*
Fixed bug on SSID profile that allowed user to select captive profile in radius select.
Reason for bug: The field value for `radiusServiceId` was set using the profile at the 0th index of child profiles (`childProfiles.[0]`)
Solution: Find the radius profile if it exists instead of hardcoding the index

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*