### PR TITLE
Bugfix/NETEXP-1395: fixed freeMemory label + made OS stats y-axis more consistent

### DIFF
--- a/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
+++ b/src/containers/AccessPointDetails/components/OS/components/HighChartGraph/index.js
@@ -46,7 +46,7 @@ const dateTimeLabelFormats = {
   year: '',
 };
 
-const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
+const HighChartGraph = ({ loading, cpuUsage, freeMemory, maxFreeMemory, cpuTemp }) => {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -97,6 +97,8 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
         }}
         visible={visible}
         showEmpty={false}
+        min={0}
+        max={100}
       >
         <YAxis.Title
           style={{
@@ -125,6 +127,8 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
         opposite
         visible={visible}
         showEmpty={false}
+        min={0}
+        max={maxFreeMemory}
       >
         <YAxis.Title
           style={{
@@ -144,6 +148,8 @@ const HighChartGraph = ({ loading, cpuUsage, freeMemory, cpuTemp }) => {
         }}
         visible={visible}
         showEmpty={false}
+        min={0}
+        max={100}
       >
         <YAxis.Title
           style={{
@@ -162,6 +168,7 @@ HighChartGraph.propTypes = {
   loading: PropTypes.bool,
   cpuUsage: PropTypes.instanceOf(Object),
   freeMemory: PropTypes.instanceOf(Object),
+  maxFreeMemory: PropTypes.number,
   cpuTemp: PropTypes.instanceOf(Object),
 };
 
@@ -169,6 +176,7 @@ HighChartGraph.defaultProps = {
   loading: false,
   cpuUsage: [],
   freeMemory: {},
+  maxFreeMemory: 0,
   cpuTemp: {},
 };
 

--- a/src/containers/AccessPointDetails/components/OS/index.js
+++ b/src/containers/AccessPointDetails/components/OS/index.js
@@ -32,7 +32,8 @@ const OS = ({ data, osData, handleRefresh }) => {
     metrics.forEach(i => {
       if (i?.detailsJSON?.apPerformance) {
         const time = parseInt(i.createdTimestamp, 10);
-        freeMemory.push([time, i.detailsJSON.apPerformance.freeMemory]);
+        // Convert freeMemory (Kb) to (Bytes) for byte formatters
+        freeMemory.push([time, i.detailsJSON.apPerformance.freeMemory * 1000]);
         cpuTemperature.push([time, i.detailsJSON.apPerformance.cpuTemperature]);
         i.detailsJSON.apPerformance.cpuUtilized.forEach((j, index) => {
           if (!(index in cpuUtilCores)) {
@@ -94,6 +95,7 @@ const OS = ({ data, osData, handleRefresh }) => {
         loading={osData?.loading}
         cpuUsage={metrics.cpuUtilCores}
         freeMemory={metrics.freeMemory}
+        maxFreeMemory={Math.round(osPerformance?.totalAvailableMemoryKb * 1000)}
         cpuTemp={metrics.cpuTemperature}
       />
     </Card>


### PR DESCRIPTION
JIRA: [NETEXP-1395](https://connectustechnologies.atlassian.net/browse/NETEXP-1395)

## Description
*Summary of this PR*
- made y-axis of OS stats graphs more consistent having min and max values
- Note in image free memory is not the actual max (510 Mb), graph shows 572 Mb due to axis being shared by 3 different properties.
- fixed label to show Mb instead of Kb, by formatting all values to Bytes for the Byte formatters
- related to cmap PR NETEXP-1395 https://bitbucket.org/connectustechnologies/cmap-ui/pull-requests/149

### Before this PR
*Screenshots of what it looked like before this PR*
![Screen Shot 2021-04-05 at 3 57 24 PM](https://user-images.githubusercontent.com/70719869/113620635-97870a80-9628-11eb-93d7-f593129028b8.png)

### After this PR
*Screenshots of what it will look like after this PR*
![Screen Shot 2021-04-05 at 3 52 07 PM](https://user-images.githubusercontent.com/70719869/113620657-a1a90900-9628-11eb-8a7d-75efa126842e.png)
