### PR TITLE
bugfix/WIFI-1992: Fixed radiusAcountingServiceInterval input

### DIFF
--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -74,7 +74,9 @@ const SSIDForm = ({
       },
       ...radioBasedValues,
       childProfileIds: [],
-      radiusAcountingServiceInterval: details?.radiusAcountingServiceInterval || '',
+      radiusAcountingServiceInterval:
+        details?.radiusAcountingServiceInterval ||
+        defaultSsidProfile.radiusAcountingServiceInterval,
       dynamicVlan: details?.dynamicVlan || defaultSsidProfile.dynamicVlan,
     });
   }, [form, details]);
@@ -373,25 +375,32 @@ const SSIDForm = ({
               name="radiusAcountingServiceInterval"
               label="RADIUS Accounting Interval"
               rules={[
+                {
+                  required: true,
+                  message: 'Please enter a RADIUS accounting interval',
+                },
                 () => ({
                   validator(_rule, value) {
-                    if (!value || (value >= 60 && value <= 600)) {
+                    if (!value || (value >= 60 && value <= 600) || value === '0') {
                       return Promise.resolve();
                     }
-                    return Promise.reject(
-                      new Error('RADIUS accounting interval can be a number between 60 and 600')
-                    );
+                    return Promise.reject(new Error('0 or 60 - 600'));
                   },
                 }),
               ]}
             >
               <Input
                 className={globalStyles.field}
-                placeholder="No RADIUS Accounting Interval"
+                placeholder="0 or 60 - 600 "
                 type="number"
                 min={60}
                 max={600}
-                addonAfter={<Tooltip title="Interval range between 60-600" text="Seconds" />}
+                addonAfter={
+                  <Tooltip
+                    title="Interval can be 0 or a number between 60 and 600"
+                    text="Seconds"
+                  />
+                }
               />
             </Item>
           </>

--- a/src/containers/ProfileDetails/components/SSID/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/SSID/tests/index.test.js
@@ -394,7 +394,7 @@ describe('<SSIDForm />', () => {
     fireEvent.click(getByText(mockSsid.radiusProfiles[0].name));
   });
 
-  it('Should show errors if Radius Accounting Interval is outside range of 60-600', async () => {
+  it('Should show errors if Radius Accounting Interval is outside range of 60-600 or not 0', async () => {
     const SSIDFormComp = () => {
       const [form] = Form.useForm();
       return (
@@ -404,7 +404,7 @@ describe('<SSIDForm />', () => {
       );
     };
 
-    const { getByText, container, getByLabelText } = render(<SSIDFormComp />);
+    const { getByText, container, getByLabelText, queryByText } = render(<SSIDFormComp />);
 
     const selectMode = container.querySelector('[data-testid=securityMode] > .ant-select-selector');
     fireEvent.mouseDown(selectMode);
@@ -414,12 +414,26 @@ describe('<SSIDForm />', () => {
     await waitFor(() => {
       expect(getByText('RADIUS Accounting Interval')).toBeVisible();
     });
+
+    const errorMsg = '0 or 60 - 600';
     fireEvent.change(getByLabelText('RADIUS Accounting Interval'), { target: { value: '59' } });
     await waitFor(() => {
-      expect(
-        getByText('RADIUS accounting interval can be a number between 60 and 600')
-      ).toBeVisible();
+      expect(getByText(errorMsg)).toBeVisible();
     });
+
+    fireEvent.change(getByLabelText('RADIUS Accounting Interval'), { target: { value: '601' } });
+    await waitFor(() => {
+      expect(getByText(errorMsg)).toBeVisible();
+    });
+
     fireEvent.change(getByLabelText('RADIUS Accounting Interval'), { target: { value: '600' } });
+    await waitFor(() => {
+      expect(queryByText(errorMsg)).not.toBeInTheDocument();
+    });
+
+    fireEvent.change(getByLabelText('RADIUS Accounting Interval'), { target: { value: '0' } });
+    await waitFor(() => {
+      expect(queryByText(errorMsg)).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/containers/ProfileDetails/components/constants.js
+++ b/src/containers/ProfileDetails/components/constants.js
@@ -203,7 +203,7 @@ const defaultSsidProfile = {
   noLocalSubnets: false,
   radiusServiceName: null,
   radiusAccountingServiceName: null,
-  radiusAcountingServiceInterval: 60,
+  radiusAcountingServiceInterval: 0,
   captivePortalId: null,
   bandwidthLimitDown: 0,
   bandwidthLimitUp: 0,


### PR DESCRIPTION
JIRA: [WIFI-1992](https://telecominfraproject.atlassian.net/browse/WIFI-1992)

## Description
*Summary of this PR*
Allowed `radiusAcountingServiceInterval` to support valid input of 0, and made 0 the default value. 

### Before this PR
*Screenshots of what it looked like before this PR*
Input used to support `null` input
![image](https://user-images.githubusercontent.com/55258316/113933789-01d3b280-97c3-11eb-8ed0-0594a478df99.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/113933685-e36db700-97c2-11eb-8315-50c9deba6037.png)

![image](https://user-images.githubusercontent.com/55258316/113933713-ecf71f00-97c2-11eb-9978-97ff7ca02ff9.png)
