### PR TITLE
bugfix/NETEXP-1461: Removed equipment discovery from Ap profiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tip-wlan/wlan-cloud-ui-library",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/LocationsTree/tests/index.test.js
+++ b/src/components/LocationsTree/tests/index.test.js
@@ -52,7 +52,6 @@ const apProfiles = [
       rtlsSettings: null,
       syntheticClientEnabled: true,
       ledControlEnabled: true,
-      equipmentDiscovery: false,
       radioMap: {
         is2dot4GHz: {
           model_type: 'RadioProfileConfiguration',
@@ -93,7 +92,6 @@ const apProfiles = [
       rtlsSettings: null,
       syntheticClientEnabled: true,
       ledControlEnabled: true,
-      equipmentDiscovery: false,
       radioMap: {
         is5GHz: {
           model_type: 'RadioProfileConfiguration',

--- a/src/containers/AutoProvision/components/FormModal/tests/index.test.js
+++ b/src/containers/AutoProvision/components/FormModal/tests/index.test.js
@@ -43,7 +43,6 @@ const mockProps = {
         rtlsSettings: null,
         syntheticClientEnabled: true,
         ledControlEnabled: true,
-        equipmentDiscovery: false,
         radioMap: {
           is2dot4GHz: {
             model_type: 'RadioProfileConfiguration',
@@ -84,7 +83,6 @@ const mockProps = {
         rtlsSettings: null,
         syntheticClientEnabled: true,
         ledControlEnabled: true,
-        equipmentDiscovery: false,
         radioMap: {
           is5GHz: {
             model_type: 'RadioProfileConfiguration',
@@ -120,7 +118,6 @@ const mockProps = {
         rtlsSettings: null,
         syntheticClientEnabled: true,
         ledControlEnabled: true,
-        equipmentDiscovery: false,
         radioMap: {
           is5GHz: {
             model_type: 'RadioProfileConfiguration',

--- a/src/containers/ProfileDetails/components/AccessPoint/index.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/index.js
@@ -99,7 +99,6 @@ const AccessPointForm = ({
         severity: details?.syslogRelay?.severity || defaultApProfile.syslogRelay.severity,
       },
       syntheticClientEnabled: details?.syntheticClientEnabled ? 'true' : 'false',
-      equipmentDiscovery: details?.equipmentDiscovery ? 'true' : 'false',
       rfProfileId: currentRfId,
     });
   }, [form, details]);
@@ -410,18 +409,6 @@ const AccessPointForm = ({
             {
               required: true,
               message: 'Please select your Synthetic Client setting',
-            },
-          ]}
-        >
-          {enabledRadioOptions()}
-        </Item>
-        <Item
-          label="Equipment Discovery"
-          name="equipmentDiscovery"
-          rules={[
-            {
-              required: true,
-              message: 'Please select your Equipment Discovery setting',
             },
           ]}
         >

--- a/src/containers/ProfileDetails/components/AccessPoint/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/tests/index.test.js
@@ -73,7 +73,6 @@ describe('<AccessPoints />', () => {
         rtlsSettings: { enabled: true },
         syslogRelay: { enabled: true },
         syntheticClientEnabled: false,
-        equipmentDiscovery: true,
       },
     };
     const AccessPointComp = () => {

--- a/src/containers/ProfileDetails/components/constants.js
+++ b/src/containers/ProfileDetails/components/constants.js
@@ -276,7 +276,6 @@ const defaultApProfile = {
   },
   syntheticClientEnabled: false,
   ledControlEnabled: true,
-  equipmentDiscovery: false,
   radioMap: {
     is5GHz: {
       model_type: 'RadioProfileConfiguration',

--- a/src/containers/ProfileDetails/tests/constants.js
+++ b/src/containers/ProfileDetails/tests/constants.js
@@ -10,7 +10,6 @@ const fakeSsid = generateSsidProfile();
 
 export const mockAccessPoint = {
   details: {
-    equipmentDiscovery: false,
     equipmentType: 'AP',
     ledControlEnabled: true,
     model_type: 'ApNetworkConfiguration',

--- a/src/containers/ProfileDetails/tests/utils.js
+++ b/src/containers/ProfileDetails/tests/utils.js
@@ -131,7 +131,6 @@ export function generateApProfile(radioMap) {
     name: faker.commerce.productName(),
     profileType: 'equipment_ap',
     details: {
-      equipmentDiscovery: false,
       equipmentType: 'AP',
       ledControlEnabled: true,
       model_type: 'ApNetworkConfiguration',

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -104,7 +104,6 @@ export const formatSsidProfileForm = values => {
 export const formatApProfileForm = values => {
   const formattedData = { ...values };
 
-  formattedData.equipmentDiscovery = isBool(values.equipmentDiscovery);
   formattedData.rtlsSettings.enabled = isBool(values.rtlsSettings.enabled);
   formattedData.syntheticClientEnabled = isBool(values.syntheticClientEnabled);
   formattedData.syslogRelay.enabled = isBool(values.syslogRelay.enabled);


### PR DESCRIPTION
JIRA: [NETEXP-1461](https://connectustechnologies.atlassian.net/browse/NETEXP-1461)

## Description
*Summary of this PR*
 - removed `equipmentDiscovery` from AP profile page and related such as testing files and utils validation
 
### Before this PR
*Screenshots of what it looked like before this PR*
![Screen Shot 2021-04-08 at 3 10 19 PM](https://user-images.githubusercontent.com/70719869/114084984-c4ccf600-987e-11eb-926b-d57e5cbe906b.png)


### After this PR
*Screenshots of what it will look like after this PR*
![Screen Shot 2021-04-08 at 3 09 40 PM](https://user-images.githubusercontent.com/70719869/114084943-b979ca80-987e-11eb-9aa0-3463ddd4d9a5.png)
