### PR TITLE
bugfix/NETEXP-1450: removed network & country from PLMN table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tip-wlan/wlan-cloud-ui-library",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/containers/ProfileDetails/components/ProviderId/index.js
+++ b/src/containers/ProfileDetails/components/ProviderId/index.js
@@ -68,14 +68,6 @@ const ProviderIdForm = ({ form, details, handleOnFormChange }) => {
       dataIndex: 'mnc',
     },
     {
-      title: 'Country',
-      dataIndex: 'country',
-    },
-    {
-      title: 'Network',
-      dataIndex: 'network',
-    },
-    {
       title: '',
       width: 80,
       render: item => (


### PR DESCRIPTION
JIRA: [NETEXP-1450](https://connectustechnologies.atlassian.net/browse/NETEXP-1450)

## Description
*Summary of this PR*
- removed country and network from PLMN table
- these fields were already removed in the `plmnModal` 

### Before this PR
*Screenshots of what it looked like before this PR*
![Screen Shot 2021-04-12 at 10 54 11 AM](https://user-images.githubusercontent.com/70719869/114417620-bf71f300-9b7f-11eb-9e3e-d442e2ed8a71.png)


### After this PR
*Screenshots of what it will look like after this PR*
![Screen Shot 2021-04-12 at 11 06 35 AM](https://user-images.githubusercontent.com/70719869/114417640-c436a700-9b7f-11eb-93cc-20f5ed159b8b.png)
