### PR TITLE
Bugfix/WIFI-2039: Disabled Captive Portal field when Mode is NAT

### DIFF
--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -269,36 +269,43 @@ const SSIDForm = ({
         >
           {({ getFieldValue }) => {
             return (
-              <Item
-                name="noLocalSubnets"
-                label={
-                  <span>
-                    <Tooltip
-                      title="When a wireless network is configured with 'No Local Access', users will have internet access only. Any traffic to internal resources (other than DHCP and DNS) will be denied."
-                      text="Local Access"
-                    />
-                  </span>
-                }
-              >
-                {getFieldValue('forwardMode') === 'BRIDGE' ? (
-                  <Radio.Group>
-                    <Radio value="false">Allow Local Access</Radio>
-                    <Radio value="true">No Local Access</Radio>
-                  </Radio.Group>
-                ) : (
-                  <span className={styles.Disclaimer}>Not Applicable</span>
-                )}
-              </Item>
+              <>
+                <Item
+                  name="noLocalSubnets"
+                  label={
+                    <span>
+                      <Tooltip
+                        title="When a wireless network is configured with 'No Local Access', users will have internet access only. Any traffic to internal resources (other than DHCP and DNS) will be denied."
+                        text="Local Access"
+                      />
+                    </span>
+                  }
+                >
+                  {getFieldValue('forwardMode') === 'BRIDGE' ? (
+                    <Radio.Group>
+                      <Radio value="false">Allow Local Access</Radio>
+                      <Radio value="true">No Local Access</Radio>
+                    </Radio.Group>
+                  ) : (
+                    <span className={styles.Disclaimer}>Not Applicable</span>
+                  )}
+                </Item>
+
+                <Item label="Captive Portal" name="captivePortal">
+                  {getFieldValue('forwardMode') === 'BRIDGE' ? (
+                    <Radio.Group>
+                      <Radio value="notPortal">Do Not Use</Radio>
+                      <Radio value="usePortal">Use</Radio>
+                    </Radio.Group>
+                  ) : (
+                    <span className={styles.Disclaimer}>Not Applicable</span>
+                  )}
+                </Item>
+              </>
             );
           }}
         </Item>
 
-        <Item label="Captive Portal" name="captivePortal">
-          <Radio.Group>
-            <Radio value="notPortal">Do Not Use</Radio>
-            <Radio value="usePortal">Use</Radio>
-          </Radio.Group>
-        </Item>
         <Item
           noStyle
           shouldUpdate={(prevValues, currentValues) =>

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -309,11 +309,13 @@ const SSIDForm = ({
         <Item
           noStyle
           shouldUpdate={(prevValues, currentValues) =>
-            prevValues.captivePortal !== currentValues.captivePortal
+            prevValues.captivePortal !== currentValues.captivePortal ||
+            prevValues.forwardMode !== currentValues.forwardMode
           }
         >
           {({ getFieldValue }) => {
-            return getFieldValue('captivePortal') === 'usePortal' ? (
+            return getFieldValue('forwardMode') === 'BRIDGE' &&
+              getFieldValue('captivePortal') === 'usePortal' ? (
               <Item wrapperCol={{ offset: 5, span: 15 }} name="captivePortalId">
                 <Select
                   className={globalStyles.field}

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -309,8 +309,8 @@ const SSIDForm = ({
         <Item
           noStyle
           shouldUpdate={(prevValues, currentValues) =>
-            prevValues.captivePortal !== currentValues.captivePortal ||
-            prevValues.forwardMode !== currentValues.forwardMode
+            prevValues.forwardMode !== currentValues.forwardMode ||
+            prevValues.captivePortal !== currentValues.captivePortal
           }
         >
           {({ getFieldValue }) => {

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -68,7 +68,7 @@ export const formatSsidProfileForm = values => {
     });
   });
 
-  if (values.captivePortal === 'usePortal') {
+  if (values.forwardMode === 'BRIDGE' && values.captivePortal === 'usePortal') {
     formattedData.childProfileIds.push(parseInt(values.captivePortalId, 10));
   } else {
     formattedData.captivePortalId = null;


### PR DESCRIPTION
JIRA: [WIFI-2039](https://telecominfraproject.atlassian.net/browse/WIFI-2039)

## Description
*Summary of this PR*
- disabled Captive portal field when mode is NAT
- add condition to `formateSSID` so when the profile is updated to Mode NAT, child captive profile will be removed

### Before this PR
*Screenshots of what it looked like before this PR*
![Screen Shot 2021-04-20 at 11 56 09 AM](https://user-images.githubusercontent.com/70719869/115433735-e068c280-a1d5-11eb-9b24-763db9fd0a1c.png)


### After this PR
*Screenshots of what it will look like after this PR*
![Screen Shot 2021-04-20 at 11 46 46 AM](https://user-images.githubusercontent.com/70719869/115433751-e363b300-a1d5-11eb-9b24-6433591a4305.png)
