### PR TITLE
hotfix/ProfileSelectSearch: Fixed profile select search behaviour

### DIFF
--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -400,7 +400,7 @@ const General = ({
             showSearch={onSearchProfile}
             filterOption={false}
             onSearch={onSearchProfile}
-            onSelect={() => onSearchProfile()}
+            onSelect={() => onSearchProfile && onSearchProfile()}
             loading={loadingProfiles}
             notFoundContent={!loadingProfiles && <Empty />}
           >

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -397,9 +397,10 @@ const General = ({
             onChange={handleProfileChange}
             placeholder="Select Access Point profile..."
             onPopupScroll={onFetchMoreProfiles}
-            showSearch
+            showSearch={onSearchProfile}
             filterOption={false}
             onSearch={onSearchProfile}
+            onSelect={() => onSearchProfile()}
             loading={loadingProfiles}
             notFoundContent={!loadingProfiles && <Empty />}
           >
@@ -600,7 +601,7 @@ General.defaultProps = {
   loadingProfiles: true,
   errorProfiles: null,
   onFetchMoreProfiles: () => {},
-  onSearchProfile: () => {},
+  onSearchProfile: null,
   extraFields: [],
   extraGeneralCards: null,
 };

--- a/src/containers/AccessPointDetails/index.js
+++ b/src/containers/AccessPointDetails/index.js
@@ -286,7 +286,7 @@ AccessPointDetails.defaultProps = {
   errorFirmware: null,
   onFetchMoreProfiles: () => {},
   extraButtons: null,
-  onSearchProfile: () => {},
+  onSearchProfile: null,
   extraFields: [],
   extraTabs: [],
   extraGeneralCards: null,

--- a/src/containers/ProfileDetails/components/AccessPoint/index.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/index.js
@@ -422,7 +422,8 @@ const AccessPointForm = ({
             showSearch={onSearchProfile}
             placeholder="Select a RF Profile"
             filterOption={false}
-            onSearch={name => onSearchProfile(name, PROFILES.rf)}
+            onSearch={name => onSearchProfile(PROFILES.rf, name)}
+            onSelect={() => onSearchProfile(PROFILES.rf)}
             loading={loadingRFProfiles}
             notFoundContent={!loadingRFProfiles && <Empty />}
           >
@@ -442,7 +443,8 @@ const AccessPointForm = ({
             showSearch={onSearchProfile}
             placeholder="Select a SSID Profile"
             filterOption={false}
-            onSearch={name => onSearchProfile(name, PROFILES.ssid)}
+            onSearch={name => onSearchProfile(PROFILES.ssid, name)}
+            onSelect={() => onSearchProfile(PROFILES.ssid)}
             loading={loadingSSIDProfiles}
             notFoundContent={!loadingSSIDProfiles && <Empty />}
             onChange={handleOnChangeSsid}

--- a/src/containers/ProfileDetails/components/AccessPoint/index.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/index.js
@@ -423,7 +423,7 @@ const AccessPointForm = ({
             placeholder="Select a RF Profile"
             filterOption={false}
             onSearch={name => onSearchProfile(PROFILES.rf, name)}
-            onSelect={() => onSearchProfile(PROFILES.rf)}
+            onSelect={() => onSearchProfile && onSearchProfile(PROFILES.rf)}
             loading={loadingRFProfiles}
             notFoundContent={!loadingRFProfiles && <Empty />}
           >
@@ -444,7 +444,7 @@ const AccessPointForm = ({
             placeholder="Select a SSID Profile"
             filterOption={false}
             onSearch={name => onSearchProfile(PROFILES.ssid, name)}
-            onSelect={() => onSearchProfile(PROFILES.ssid)}
+            onSelect={() => onSearchProfile && onSearchProfile(PROFILES.ssid)}
             loading={loadingSSIDProfiles}
             notFoundContent={!loadingSSIDProfiles && <Empty />}
             onChange={handleOnChangeSsid}

--- a/src/containers/ProfileDetails/components/CaptivePortal/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/index.js
@@ -488,7 +488,7 @@ const CaptivePortalForm = ({
               showSearch={onSearchProfile}
               filterOption={false}
               onSearch={name => onSearchProfile(PROFILES.radius, name)}
-              onSelect={() => onSearchProfile(PROFILES.radius)}
+              onSelect={() => onSearchProfile && onSearchProfile(PROFILES.radius)}
               loading={loadingRadiusProfiles}
               notFoundContent={!loadingRadiusProfiles && <Empty />}
               labelInValue

--- a/src/containers/ProfileDetails/components/CaptivePortal/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/index.js
@@ -487,7 +487,8 @@ const CaptivePortalForm = ({
               onPopupScroll={e => onFetchMoreProfiles(e, PROFILES.radius)}
               showSearch={onSearchProfile}
               filterOption={false}
-              onSearch={name => onSearchProfile(name, PROFILES.radius)}
+              onSearch={name => onSearchProfile(PROFILES.radius, name)}
+              onSelect={() => onSearchProfile(PROFILES.radius)}
               loading={loadingRadiusProfiles}
               notFoundContent={!loadingRadiusProfiles && <Empty />}
               labelInValue

--- a/src/containers/ProfileDetails/components/PasspointProfile/index.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/index.js
@@ -282,7 +282,8 @@ const PasspointProfileForm = ({
             showSearch={onSearchProfile}
             placeholder="Select a Venue Profile"
             filterOption={false}
-            onSearch={name => onSearchProfile(name, PROFILES.venue)}
+            onSearch={name => onSearchProfile(PROFILES.venue, name)}
+            onSelect={() => onSearchProfile(PROFILES.venue)}
             loading={loadingVenueProfiles}
             notFoundContent={!loadingVenueProfiles && <Empty />}
             labelInValue
@@ -301,7 +302,8 @@ const PasspointProfileForm = ({
             showSearch={onSearchProfile}
             placeholder="Select an Operator Profile"
             filterOption={false}
-            onSearch={name => onSearchProfile(name, PROFILES.operator)}
+            onSearch={name => onSearchProfile(PROFILES.operator, name)}
+            onSelect={() => onSearchProfile(PROFILES.operator)}
             loading={loadingOperatorProfiles}
             notFoundContent={!loadingOperatorProfiles && <Empty />}
             labelInValue
@@ -323,7 +325,8 @@ const PasspointProfileForm = ({
             placeholder="Select ID Providers (check to select)"
             className={styles.MultipleSelection}
             filterOption={false}
-            onSearch={name => onSearchProfile(name, PROFILES.providerID)}
+            onSearch={name => onSearchProfile(PROFILES.providerID, name)}
+            onSelect={() => onSearchProfile(PROFILES.providerID)}
             loading={loadingIdProviderProfiles}
             notFoundContent={!loadingIdProviderProfiles && <Empty />}
             labelInValue
@@ -342,7 +345,8 @@ const PasspointProfileForm = ({
             showSearch={onSearchProfile}
             placeholder="Select an SSID Profile"
             filterOption={false}
-            onSearch={name => onSearchProfile(name, PROFILES.ssid)}
+            onSearch={name => onSearchProfile(PROFILES.ssid, name)}
+            onSelect={() => onSearchProfile(PROFILES.ssid)}
             loading={loadingSSIDProfiles}
             notFoundContent={!loadingSSIDProfiles && <Empty />}
             labelInValue
@@ -390,7 +394,8 @@ const PasspointProfileForm = ({
             showSearch={onSearchProfile}
             placeholder="Select a SSID Profile"
             filterOption={false}
-            onSearch={name => onSearchProfile(name, PROFILES.ssid)}
+            onSearch={name => onSearchProfile(PROFILES.ssid, name)}
+            onSelect={() => onSearchProfile(PROFILES.ssid)}
             loading={loadingSSIDProfiles}
             notFoundContent={!loadingSSIDProfiles && <Empty />}
             onChange={handleOnChangeSsid}

--- a/src/containers/ProfileDetails/components/PasspointProfile/index.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/index.js
@@ -283,7 +283,7 @@ const PasspointProfileForm = ({
             placeholder="Select a Venue Profile"
             filterOption={false}
             onSearch={name => onSearchProfile(PROFILES.venue, name)}
-            onSelect={() => onSearchProfile(PROFILES.venue)}
+            onSelect={() => onSearchProfile && onSearchProfile(PROFILES.venue)}
             loading={loadingVenueProfiles}
             notFoundContent={!loadingVenueProfiles && <Empty />}
             labelInValue
@@ -303,7 +303,7 @@ const PasspointProfileForm = ({
             placeholder="Select an Operator Profile"
             filterOption={false}
             onSearch={name => onSearchProfile(PROFILES.operator, name)}
-            onSelect={() => onSearchProfile(PROFILES.operator)}
+            onSelect={() => onSearchProfile && onSearchProfile(PROFILES.operator)}
             loading={loadingOperatorProfiles}
             notFoundContent={!loadingOperatorProfiles && <Empty />}
             labelInValue
@@ -326,7 +326,7 @@ const PasspointProfileForm = ({
             className={styles.MultipleSelection}
             filterOption={false}
             onSearch={name => onSearchProfile(PROFILES.providerID, name)}
-            onSelect={() => onSearchProfile(PROFILES.providerID)}
+            onSelect={() => onSearchProfile && onSearchProfile(PROFILES.providerID)}
             loading={loadingIdProviderProfiles}
             notFoundContent={!loadingIdProviderProfiles && <Empty />}
             labelInValue
@@ -346,7 +346,7 @@ const PasspointProfileForm = ({
             placeholder="Select an SSID Profile"
             filterOption={false}
             onSearch={name => onSearchProfile(PROFILES.ssid, name)}
-            onSelect={() => onSearchProfile(PROFILES.ssid)}
+            onSelect={() => onSearchProfile && onSearchProfile(PROFILES.ssid)}
             loading={loadingSSIDProfiles}
             notFoundContent={!loadingSSIDProfiles && <Empty />}
             labelInValue
@@ -395,7 +395,7 @@ const PasspointProfileForm = ({
             placeholder="Select a SSID Profile"
             filterOption={false}
             onSearch={name => onSearchProfile(PROFILES.ssid, name)}
-            onSelect={() => onSearchProfile(PROFILES.ssid)}
+            onSelect={() => onSearchProfile && onSearchProfile(PROFILES.ssid)}
             loading={loadingSSIDProfiles}
             notFoundContent={!loadingSSIDProfiles && <Empty />}
             onChange={handleOnChangeSsid}

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -324,7 +324,7 @@ const SSIDForm = ({
                   showSearch={onSearchProfile}
                   filterOption={false}
                   onSearch={name => onSearchProfile(PROFILES.captivePortal, name)}
-                  onSelect={() => onSearchProfile(PROFILES.captivePortal)}
+                  onSelect={() => onSearchProfile && onSearchProfile(PROFILES.captivePortal)}
                   loading={loadingCaptiveProfiles}
                   notFoundContent={!loadingCaptiveProfiles && <Empty />}
                 >
@@ -585,7 +585,7 @@ const SSIDForm = ({
                 showSearch={onSearchProfile}
                 filterOption={false}
                 onSearch={name => onSearchProfile(PROFILES.radius, name)}
-                onSelect={() => onSearchProfile(PROFILES.radius)}
+                onSelect={() => onSearchProfile && onSearchProfile(PROFILES.radius)}
                 loading={loadingRadiusProfiles}
                 notFoundContent={!loadingRadiusProfiles && <Empty />}
                 labelInValue

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -300,7 +300,8 @@ const SSIDForm = ({
                   onPopupScroll={e => onFetchMoreProfiles(e, PROFILES.captivePortal)}
                   showSearch={onSearchProfile}
                   filterOption={false}
-                  onSearch={name => onSearchProfile(name, PROFILES.captivePortal)}
+                  onSearch={name => onSearchProfile(PROFILES.captivePortal, name)}
+                  onSelect={() => onSearchProfile(PROFILES.captivePortal)}
                   loading={loadingCaptiveProfiles}
                   notFoundContent={!loadingCaptiveProfiles && <Empty />}
                 >
@@ -378,7 +379,8 @@ const SSIDForm = ({
                 onPopupScroll={e => onFetchMoreProfiles(e, PROFILES.radius)}
                 showSearch={onSearchProfile}
                 filterOption={false}
-                onSearch={name => onSearchProfile(name, PROFILES.radius)}
+                onSearch={name => onSearchProfile(PROFILES.radius, name)}
+                onSelect={() => onSearchProfile(PROFILES.radius)}
                 loading={loadingRadiusProfiles}
                 notFoundContent={!loadingRadiusProfiles && <Empty />}
                 labelInValue


### PR DESCRIPTION
JIRA: NO_JIRA

## Description
*Summary of this PR*

- Fixed bug for all profile select drop-downs that did not reset profiles after a user made a search
- Fixed bug that showed search option for AP Details profile select when it was not needed 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/115608507-5a6f7900-a2b4-11eb-8aab-386484e07399.png)


### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/115608743-ab7f6d00-a2b4-11eb-89ad-e432d57afdc8.png)
