### PR TITLE
hotfix: Added ModalSelect component

### DIFF
--- a/src/components/ContainedSelect/index.js
+++ b/src/components/ContainedSelect/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Select as AntdSelect } from 'antd';
 
-const ModalSelect = ({ children, className, ...restProps }) => (
+const ContainedSelect = ({ children, className, ...restProps }) => (
   <AntdSelect
     className={className}
     getPopupContainer={triggerNode => triggerNode.parentElement}
@@ -12,14 +12,14 @@ const ModalSelect = ({ children, className, ...restProps }) => (
   </AntdSelect>
 );
 
-ModalSelect.propTypes = {
+ContainedSelect.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
 };
 
-ModalSelect.defaultProps = {
+ContainedSelect.defaultProps = {
   children: null,
   className: '',
 };
 
-export default ModalSelect;
+export default ContainedSelect;

--- a/src/components/ContainedSelect/index.js
+++ b/src/components/ContainedSelect/index.js
@@ -2,24 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Select as AntdSelect } from 'antd';
 
-const ContainedSelect = ({ children, className, ...restProps }) => (
-  <AntdSelect
-    className={className}
-    getPopupContainer={triggerNode => triggerNode.parentElement}
-    {...restProps}
-  >
+const ContainedSelect = ({ children, ...restProps }) => (
+  <AntdSelect getPopupContainer={triggerNode => triggerNode.parentElement} {...restProps}>
     {children}
   </AntdSelect>
 );
 
 ContainedSelect.propTypes = {
   children: PropTypes.node,
-  className: PropTypes.string,
 };
 
 ContainedSelect.defaultProps = {
   children: null,
-  className: '',
 };
 
 export default ContainedSelect;

--- a/src/components/LocaleItem/index.js
+++ b/src/components/LocaleItem/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Select, Form } from 'antd';
-import ModalSelect from 'components/ModalSelect';
+import ContainedSelect from 'components/ContainedSelect';
 
 const { Option } = Select;
 const { Item } = Form;
@@ -18,10 +18,10 @@ const LocaleDropdown = ({ name }) => {
         },
       ]}
     >
-      <ModalSelect placeholder="Please select" data-testid="localeItem">
+      <ContainedSelect placeholder="Please select" data-testid="localeItem">
         <Option value="en_CA">English</Option>
         <Option value="fr_CA">Francais</Option>
-      </ModalSelect>
+      </ContainedSelect>
     </Item>
   );
 };

--- a/src/components/LocaleItem/index.js
+++ b/src/components/LocaleItem/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Select, Form } from 'antd';
+import ModalSelect from 'components/ModalSelect';
 
 const { Option } = Select;
 const { Item } = Form;
@@ -17,10 +18,10 @@ const LocaleDropdown = ({ name }) => {
         },
       ]}
     >
-      <Select placeholder="Please select" data-testid="localeItem">
+      <ModalSelect placeholder="Please select" data-testid="localeItem">
         <Option value="en_CA">English</Option>
         <Option value="fr_CA">Francais</Option>
-      </Select>
+      </ModalSelect>
     </Item>
   );
 };

--- a/src/components/LocationsTree/components/AddApModal/index.js
+++ b/src/components/LocationsTree/components/AddApModal/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Form, Input, Select, Alert, Spin } from 'antd';
 
 import Modal from 'components/Modal';
-import ModalSelect from 'components/ModalSelect';
+import ContainedSelect from 'components/ContainedSelect';
 import { modalLayout } from 'utils/form';
 import styles from 'styles/index.scss';
 
@@ -61,7 +61,7 @@ const AddApModal = ({
           },
         ]}
       >
-        <ModalSelect
+        <ContainedSelect
           className={styles.field}
           placeholder="Select Access Point Profile"
           onPopupScroll={onFetchMoreProfiles}
@@ -72,7 +72,7 @@ const AddApModal = ({
               {profiles[i].name}
             </Option>
           ))}
-        </ModalSelect>
+        </ContainedSelect>
       </Item>
     </Form>
   );

--- a/src/components/LocationsTree/components/AddApModal/index.js
+++ b/src/components/LocationsTree/components/AddApModal/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Form, Input, Select, Alert, Spin } from 'antd';
 
 import Modal from 'components/Modal';
+import ModalSelect from 'components/ModalSelect';
 import { modalLayout } from 'utils/form';
 import styles from 'styles/index.scss';
 
@@ -60,7 +61,7 @@ const AddApModal = ({
           },
         ]}
       >
-        <Select
+        <ModalSelect
           className={styles.field}
           placeholder="Select Access Point Profile"
           onPopupScroll={onFetchMoreProfiles}
@@ -71,7 +72,7 @@ const AddApModal = ({
               {profiles[i].name}
             </Option>
           ))}
-        </Select>
+        </ModalSelect>
       </Item>
     </Form>
   );

--- a/src/components/ModalSelect/index.js
+++ b/src/components/ModalSelect/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Select as AntdSelect } from 'antd';
+
+const ModalSelect = ({ children, className, ...restProps }) => (
+  <AntdSelect
+    className={className}
+    getPopupContainer={triggerNode => triggerNode.parentElement}
+    {...restProps}
+  >
+    {children}
+  </AntdSelect>
+);
+
+ModalSelect.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+ModalSelect.defaultProps = {
+  children: null,
+  className: '',
+};
+
+export default ModalSelect;

--- a/src/containers/Accounts/components/FormModal/index.js
+++ b/src/containers/Accounts/components/FormModal/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Button, Form, Input, Select, Typography } from 'antd';
 
 import Modal from 'components/Modal';
-import ModalSelect from 'components/ModalSelect';
+import ContainedSelect from 'components/ContainedSelect';
 import styles from 'styles/index.scss';
 import { modalLayout } from 'utils/form';
 
@@ -59,10 +59,10 @@ const FormModal = ({
       </Item>
 
       <Item label="Role" name="roles" rules={[{ required: true, message: 'Please select a role' }]}>
-        <ModalSelect placeholder="Select role">
+        <ContainedSelect placeholder="Select role">
           <Option value="SuperUser">SuperUser</Option>
           <Option value="CustomerIT">CustomerIT</Option>
-        </ModalSelect>
+        </ContainedSelect>
       </Item>
       {!isAuth0Enabled && (
         <>

--- a/src/containers/Accounts/components/FormModal/index.js
+++ b/src/containers/Accounts/components/FormModal/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Button, Form, Input, Select, Typography } from 'antd';
 
 import Modal from 'components/Modal';
+import ModalSelect from 'components/ModalSelect';
 import styles from 'styles/index.scss';
 import { modalLayout } from 'utils/form';
 
@@ -58,10 +59,10 @@ const FormModal = ({
       </Item>
 
       <Item label="Role" name="roles" rules={[{ required: true, message: 'Please select a role' }]}>
-        <Select placeholder="Select role">
+        <ModalSelect placeholder="Select role">
           <Option value="SuperUser">SuperUser</Option>
           <Option value="CustomerIT">CustomerIT</Option>
-        </Select>
+        </ModalSelect>
       </Item>
       {!isAuth0Enabled && (
         <>

--- a/src/containers/AutoProvision/components/FormModal/index.js
+++ b/src/containers/AutoProvision/components/FormModal/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Form, Input, Select, Alert, Spin } from 'antd';
 
 import Modal from 'components/Modal';
+import ModalSelect from 'components/ModalSelect';
 import globalStyles from 'styles/index.scss';
 import { modalLayout } from 'utils/form';
 import styles from '../../index.module.scss';
@@ -75,7 +76,7 @@ const FormModal = ({
           },
         ]}
       >
-        <Select
+        <ModalSelect
           className={globalStyles.field}
           placeholder="Select Access Point Profile"
           onPopupScroll={e => onFetchMoreProfiles(e)}
@@ -85,7 +86,7 @@ const FormModal = ({
               {i.name}
             </Option>
           ))}
-        </Select>
+        </ModalSelect>
       </Item>
     </Form>
   );

--- a/src/containers/AutoProvision/components/FormModal/index.js
+++ b/src/containers/AutoProvision/components/FormModal/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Form, Input, Select, Alert, Spin } from 'antd';
 
 import Modal from 'components/Modal';
-import ModalSelect from 'components/ModalSelect';
+import ContainedSelect from 'components/ContainedSelect';
 import globalStyles from 'styles/index.scss';
 import { modalLayout } from 'utils/form';
 import styles from '../../index.module.scss';
@@ -76,7 +76,7 @@ const FormModal = ({
           },
         ]}
       >
-        <ModalSelect
+        <ContainedSelect
           className={globalStyles.field}
           placeholder="Select Access Point Profile"
           onPopupScroll={e => onFetchMoreProfiles(e)}
@@ -86,7 +86,7 @@ const FormModal = ({
               {i.name}
             </Option>
           ))}
-        </ModalSelect>
+        </ContainedSelect>
       </Item>
     </Form>
   );

--- a/src/containers/Firmware/components/AssignmentModal/index.js
+++ b/src/containers/Firmware/components/AssignmentModal/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Form, Select, Spin, Alert } from 'antd';
 
 import Modal from 'components/Modal';
-import ModalSelect from 'components/ModalSelect';
+import ContainedSelect from 'components/ContainedSelect';
 import globalStyles from 'styles/index.scss';
 import { modalLayout } from 'utils/form';
 import styles from '../../index.module.scss';
@@ -64,7 +64,7 @@ const AssignmentModal = ({
           },
         ]}
       >
-        <ModalSelect
+        <ContainedSelect
           className={globalStyles.field}
           placeholder="Select Model ID"
           onChange={onModelChange}
@@ -75,7 +75,7 @@ const AssignmentModal = ({
               {filteredModels[i]}
             </Option>
           ))}
-        </ModalSelect>
+        </ContainedSelect>
       </Item>
 
       <Item
@@ -91,7 +91,7 @@ const AssignmentModal = ({
         {firmwareVersionLoading ? (
           <Spin data-testid="firmwareVersionLoading" className={styles.spinner} size="large" />
         ) : (
-          <ModalSelect
+          <ContainedSelect
             className={globalStyles.field}
             placeholder="Select Firmware Version"
             disabled={title === 'Add Model Target Version' && !model}
@@ -101,7 +101,7 @@ const AssignmentModal = ({
                 {firmwareVersionData[i].versionName}
               </Option>
             ))}
-          </ModalSelect>
+          </ContainedSelect>
         )}
       </Item>
     </Form>

--- a/src/containers/Firmware/components/AssignmentModal/index.js
+++ b/src/containers/Firmware/components/AssignmentModal/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Form, Select, Spin, Alert } from 'antd';
 
 import Modal from 'components/Modal';
+import ModalSelect from 'components/ModalSelect';
 import globalStyles from 'styles/index.scss';
 import { modalLayout } from 'utils/form';
 import styles from '../../index.module.scss';
@@ -63,7 +64,7 @@ const AssignmentModal = ({
           },
         ]}
       >
-        <Select
+        <ModalSelect
           className={globalStyles.field}
           placeholder="Select Model ID"
           onChange={onModelChange}
@@ -74,7 +75,7 @@ const AssignmentModal = ({
               {filteredModels[i]}
             </Option>
           ))}
-        </Select>
+        </ModalSelect>
       </Item>
 
       <Item
@@ -90,7 +91,7 @@ const AssignmentModal = ({
         {firmwareVersionLoading ? (
           <Spin data-testid="firmwareVersionLoading" className={styles.spinner} size="large" />
         ) : (
-          <Select
+          <ModalSelect
             className={globalStyles.field}
             placeholder="Select Firmware Version"
             disabled={title === 'Add Model Target Version' && !model}
@@ -100,7 +101,7 @@ const AssignmentModal = ({
                 {firmwareVersionData[i].versionName}
               </Option>
             ))}
-          </Select>
+          </ModalSelect>
         )}
       </Item>
     </Form>

--- a/src/containers/ProfileDetails/components/PasspointProfile/components/FormModal/index.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/components/FormModal/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Input, Select, Form } from 'antd';
 import Modal from 'components/Modal';
-import ModalSelect from 'components/ModalSelect';
+import ContainedSelect from 'components/ContainedSelect';
 import { modalLayout } from 'utils/form';
 
 const { Item } = Form;
@@ -40,21 +40,21 @@ const FormModal = ({ visible, onCancel, onSubmit, currentPortList, title }) => {
             name="connectionCapabilitiesStatus"
             rules={[{ required: true, message: 'Status field cannot be empty' }]}
           >
-            <ModalSelect placeholder="Select a status">
+            <ContainedSelect placeholder="Select a status">
               <Option value="open">Open</Option>
               <Option value="closed">Closed</Option>
-            </ModalSelect>
+            </ContainedSelect>
           </Item>
           <Item
             label="Protocol"
             name="connectionCapabilitiesIpProtocol"
             rules={[{ required: true, message: 'Protocol field cannot be empty' }]}
           >
-            <ModalSelect placeholder="Select a protocol">
+            <ContainedSelect placeholder="Select a protocol">
               <Option value="ICMP">ICMP</Option>
               <Option value="TCP">TCP</Option>
               <Option value="UDP">UDP</Option>
-            </ModalSelect>
+            </ContainedSelect>
           </Item>
           <Item
             label="Port"

--- a/src/containers/ProfileDetails/components/PasspointProfile/components/FormModal/index.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/components/FormModal/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Input, Select, Form } from 'antd';
 import Modal from 'components/Modal';
+import ModalSelect from 'components/ModalSelect';
 import { modalLayout } from 'utils/form';
 
 const { Item } = Form;
@@ -39,21 +40,21 @@ const FormModal = ({ visible, onCancel, onSubmit, currentPortList, title }) => {
             name="connectionCapabilitiesStatus"
             rules={[{ required: true, message: 'Status field cannot be empty' }]}
           >
-            <Select placeholder="Select a status">
+            <ModalSelect placeholder="Select a status">
               <Option value="open">Open</Option>
               <Option value="closed">Closed</Option>
-            </Select>
+            </ModalSelect>
           </Item>
           <Item
             label="Protocol"
             name="connectionCapabilitiesIpProtocol"
             rules={[{ required: true, message: 'Protocol field cannot be empty' }]}
           >
-            <Select placeholder="Select a protocol">
+            <ModalSelect placeholder="Select a protocol">
               <Option value="ICMP">ICMP</Option>
               <Option value="TCP">TCP</Option>
               <Option value="UDP">UDP</Option>
-            </Select>
+            </ModalSelect>
           </Item>
           <Item
             label="Port"

--- a/src/containers/ProfileDetails/components/ProviderId/components/NaiRealm/index.js
+++ b/src/containers/ProfileDetails/components/ProviderId/components/NaiRealm/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Card, Form, Cascader, Button, Table, Select, Input } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import Modal from 'components/Modal';
+import ModalSelect from 'components/ModalSelect';
 import _ from 'lodash';
 import { authOptions } from './constants';
 
@@ -162,7 +163,7 @@ const NaiRealm = ({ eapMap, form, addEap, removeEap }) => {
                   },
                 ]}
               >
-                <Select placeholder="Please select" data-testid="method">
+                <ModalSelect placeholder="Please select" data-testid="method">
                   <Option value="EAP-TLS with certificate" data-testid="eapCertificate">
                     EAP-TLS with certificate
                   </Option>
@@ -174,7 +175,7 @@ const NaiRealm = ({ eapMap, form, addEap, removeEap }) => {
                   </Option>
                   <Option value="EAP-AKA Authentication">EAP-AKA Authentication</Option>
                   <Option value="EAP-AKA'">EAP-AKA Prime</Option>
-                </Select>
+                </ModalSelect>
               </Item>
               <Item
                 name="auth"

--- a/src/containers/ProfileDetails/components/ProviderId/components/NaiRealm/index.js
+++ b/src/containers/ProfileDetails/components/ProviderId/components/NaiRealm/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Card, Form, Cascader, Button, Table, Select, Input } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import Modal from 'components/Modal';
-import ModalSelect from 'components/ModalSelect';
+import ContainedSelect from 'components/ContainedSelect';
 import _ from 'lodash';
 import { authOptions } from './constants';
 
@@ -163,7 +163,7 @@ const NaiRealm = ({ eapMap, form, addEap, removeEap }) => {
                   },
                 ]}
               >
-                <ModalSelect placeholder="Please select" data-testid="method">
+                <ContainedSelect placeholder="Please select" data-testid="method">
                   <Option value="EAP-TLS with certificate" data-testid="eapCertificate">
                     EAP-TLS with certificate
                   </Option>
@@ -175,7 +175,7 @@ const NaiRealm = ({ eapMap, form, addEap, removeEap }) => {
                   </Option>
                   <Option value="EAP-AKA Authentication">EAP-AKA Authentication</Option>
                   <Option value="EAP-AKA'">EAP-AKA Prime</Option>
-                </ModalSelect>
+                </ContainedSelect>
               </Item>
               <Item
                 name="auth"

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ export { default as BulkEditAccessPoints } from 'components/BulkEditAccessPoints
 export { default as Button } from 'components/Button';
 export { default as ToggleButton } from 'components/ToggleButton';
 export { default as Modal } from 'components/Modal';
+export { default as ModalSelect } from 'components/ModalSelect';
 export { default as Header } from 'components/Header';
 export { default as Container } from 'components/Container';
 export { default as DeleteButton } from 'components/DeleteButton';

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export { default as BulkEditAccessPoints } from 'components/BulkEditAccessPoints
 export { default as Button } from 'components/Button';
 export { default as ToggleButton } from 'components/ToggleButton';
 export { default as Modal } from 'components/Modal';
-export { default as ModalSelect } from 'components/ModalSelect';
+export { default as ContainedSelect } from 'components/ContainedSelect';
 export { default as Header } from 'components/Header';
 export { default as Container } from 'components/Container';
 export { default as DeleteButton } from 'components/DeleteButton';


### PR DESCRIPTION
JIRA: [NO JIRA](LINK)

## Description
*Summary of this PR*
- added reusable ContainedSelect component that uses `getPopupContainer` to ensure the select within a modal is the parent. By default the parent is the body
- used ContainedSelect in all instances where there was a select within a modal

### Before this PR
*Screenshots of what it looked like before this PR*
![Screen Shot 2021-04-21 at 3 33 07 PM](https://user-images.githubusercontent.com/70719869/115610795-53963580-a2b7-11eb-8ae8-09506ff73d07.png)
![Screen Shot 2021-04-21 at 3 33 27 PM](https://user-images.githubusercontent.com/70719869/115610807-585ae980-a2b7-11eb-8e2d-eb99d6c56e5f.png)
![Screen Shot 2021-04-21 at 3 34 18 PM](https://user-images.githubusercontent.com/70719869/115610814-5d1f9d80-a2b7-11eb-8f20-f69679eec8f6.png)
![Screen Shot 2021-04-21 at 3 38 03 PM](https://user-images.githubusercontent.com/70719869/115611059-9e17b200-a2b7-11eb-9bd5-ad4300b812a4.png)


### After this PR
*Screenshots of what it will look like after this PR*
![Screen Shot 2021-04-21 at 3 32 39 PM](https://user-images.githubusercontent.com/70719869/115610866-6e68aa00-a2b7-11eb-843e-5029ae2fc517.png)
![Screen Shot 2021-04-21 at 3 34 01 PM](https://user-images.githubusercontent.com/70719869/115611277-dd460300-a2b7-11eb-895c-d76cca9d189e.png)
Note this LocalItem was used in 3 other places, didn't add the images as they will all be the same
![Screen Shot 2021-04-21 at 3 37 43 PM](https://user-images.githubusercontent.com/70719869/115611073-a112a280-a2b7-11eb-986d-c15c6ce0e620.png)

