### PR TITLE
Bugfix/WIFI-2039: Disable Captive Portal for BRIDGE mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tip-wlan/wlan-cloud-ui-library",
-  "version": "1.1.7",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -292,7 +292,7 @@ const SSIDForm = ({
                 </Item>
 
                 <Item label="Captive Portal" name="captivePortal">
-                  {getFieldValue('forwardMode') === 'BRIDGE' ? (
+                  {getFieldValue('forwardMode') === 'NAT' ? (
                     <Radio.Group>
                       <Radio value="notPortal">Do Not Use</Radio>
                       <Radio value="usePortal">Use</Radio>
@@ -314,7 +314,7 @@ const SSIDForm = ({
           }
         >
           {({ getFieldValue }) => {
-            return getFieldValue('forwardMode') === 'BRIDGE' &&
+            return getFieldValue('forwardMode') === 'NAT' &&
               getFieldValue('captivePortal') === 'usePortal' ? (
               <Item wrapperCol={{ offset: 5, span: 15 }} name="captivePortalId">
                 <Select

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -68,7 +68,7 @@ export const formatSsidProfileForm = values => {
     });
   });
 
-  if (values.forwardMode === 'BRIDGE' && values.captivePortal === 'usePortal') {
+  if (values.forwardMode === 'NAT' && values.captivePortal === 'usePortal') {
     formattedData.childProfileIds.push(parseInt(values.captivePortalId, 10));
   } else {
     formattedData.captivePortalId = null;


### PR DESCRIPTION
JIRA: [WIFI-2039:](https://telecominfraproject.atlassian.net/browse/WIFI-2039)

## Description
*Summary of this PR*
- did the opposite before. 
- now disabled Captive Portal when mode is BRIDGE and enabled when mode is NAT

### Before this PR
*Screenshots of what it looked like before this PR*
![Screen Shot 2021-04-22 at 4 34 15 PM](https://user-images.githubusercontent.com/70719869/115782161-582b1e80-a389-11eb-956c-38b730d4cbc2.png)
![Screen Shot 2021-04-22 at 4 34 19 PM](https://user-images.githubusercontent.com/70719869/115782171-5c573c00-a389-11eb-83b1-e3eb7fbb413f.png)


### After this PR
*Screenshots of what it will look like after this PR*
![Screen Shot 2021-04-22 at 4 33 47 PM](https://user-images.githubusercontent.com/70719869/115782129-4fd2e380-a389-11eb-9d71-6e2f533f7fa7.png)
![Screen Shot 2021-04-22 at 4 33 59 PM](https://user-images.githubusercontent.com/70719869/115782152-55c8c480-a389-11eb-91e3-7bce6b713326.png)

