### PR TITLE
bugfix/WIFI:2056: Added Multiple NTP server support

### DIFF
--- a/src/containers/AddProfile/index.js
+++ b/src/containers/AddProfile/index.js
@@ -114,6 +114,14 @@ const AddProfile = ({
             });
             return;
           }
+
+          if (!values.ntpServer.auto && !values.ntpServer.value) {
+            notification.error({
+              message: 'Error',
+              description: 'At least 1 NTP Server is required.',
+            });
+            return;
+          }
           formattedData.childProfileIds.push(values.rfProfileId);
           formattedData.model_type = 'ApNetworkConfiguration';
           formattedData = Object.assign(formattedData, formatApProfileForm(values));

--- a/src/containers/ProfileDetails/components/AccessPoint/index.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Card, Form, Input, Checkbox, Radio, Select, Table, Empty } from 'antd';
+import { Card, Form, Input, Checkbox, Radio, Select, Table, Empty, List } from 'antd';
 import { DeleteFilled } from '@ant-design/icons';
 import ThemeContext from 'contexts/ThemeContext';
 
@@ -32,12 +32,9 @@ const AccessPointForm = ({
 
   const [greModalVisible, setGreModalVisible] = useState(false);
   const [greList, setGreList] = useState(details?.greTunnelConfigurations || []);
-
-  const [vlan, setVlan] = useState(details?.vlanNative === undefined ? true : details.vlanNative);
-  const [ntp, setNTP] = useState(details?.ntpServer?.auto ?? defaultApProfile.ntpServer.auto);
-
-  const [rtls, setRtls] = useState(details?.rtlsSettings?.enabled);
-  const [syslog, setSyslog] = useState(details?.syslogRelay?.enabled);
+  const [ntpServers, setNtpServers] = useState([]);
+  const [ntpServerSearch, setNtpServerSearch] = useState('');
+  const [ntpServerValidation, setNtpServerValidation] = useState({});
 
   const currentRfId = useMemo(() => childProfiles.find(i => i.profileType === 'rf')?.id, [
     childProfiles,
@@ -83,7 +80,7 @@ const AccessPointForm = ({
       vlan: details?.vlan || defaultApProfile.vlan,
       ntpServer: {
         auto: details?.ntpServer?.auto ?? defaultApProfile.ntpServer.auto,
-        value: details?.ntpServer?.value || defaultApProfile.ntpServer.value,
+        value: details?.ntpServer?.value ?? defaultApProfile.ntpServer.value,
       },
       ledControlEnabled: details?.ledControlEnabled || defaultApProfile.ledControlEnabled,
       rtlsSettings: {
@@ -101,6 +98,7 @@ const AccessPointForm = ({
       syntheticClientEnabled: details?.syntheticClientEnabled ? 'true' : 'false',
       rfProfileId: currentRfId,
     });
+    setNtpServers(details?.ntpServer?.value?.split(':'));
   }, [form, details]);
 
   useEffect(() => {
@@ -181,66 +179,208 @@ const AccessPointForm = ({
     i => !selectedChildProfiles.map(ssid => parseInt(ssid.id, 10)).includes(parseInt(i.id, 10))
   );
 
+  const validateNtpServer = (_rule, value) => {
+    const ntpServerParts = value.split('.').reverse();
+
+    if (ntpServers.length >= 4) {
+      return Promise.reject(new Error('Unable to add more than 4 items to the server list'));
+    }
+
+    if (ntpServerParts.length < 2) {
+      return Promise.reject(
+        new Error('Hostnames must have at least 1 subdomain label. e.g. ntp.pool.org')
+      );
+    }
+
+    if (!ntpServerParts.every(part => part.length >= 1 && part.length <= 63)) {
+      return Promise.reject(new Error('Hostname labels must be between 1 and 63 characters long'));
+    }
+
+    if (value.length > 253) {
+      return Promise.reject(new Error('Hostnames may not exceed 253 characters in length'));
+    }
+
+    if (ntpServers.includes(value)) {
+      return Promise.reject(new Error('This item already exists in the server list'));
+    }
+
+    // from https://www.regextester.com/23
+    if (
+      !value.match(
+        /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/
+      )
+    ) {
+      return Promise.reject(new Error('Unrecognized hostname'));
+    }
+
+    return Promise.resolve();
+  };
+
+  const handleOnAddServer = value => {
+    validateNtpServer(null, value)
+      .then(() => {
+        setNtpServers([...ntpServers, value.toLowerCase().trim()]);
+        setNtpServerSearch('');
+      })
+      .catch(() => {});
+  };
+
+  const handleOnDeleteServer = item => {
+    setNtpServers(ntpServers.filter(i => i !== item));
+    handleOnFormChange();
+  };
+
+  const handleOnChangeNtpServer = event => {
+    setNtpServerSearch(event.target.value);
+    validateNtpServer(null, event.target.value)
+      .then(() => {
+        setNtpServerValidation({
+          status: null,
+          help: null,
+        });
+        handleOnFormChange();
+      })
+      .catch(e => {
+        setNtpServerValidation({
+          status: 'error',
+          help: e.message,
+        });
+      });
+  };
+
+  useEffect(() => {
+    form.setFieldsValue({
+      ntpServer: {
+        value: ntpServers?.join(':'),
+      },
+    });
+  }, [ntpServers]);
+
   return (
     <div className={styles.ProfilePage}>
       <Card title="LAN and Services ">
         <Item label="Management VLAN" valuePropName="checked" name="vlanNative">
-          <Checkbox data-testid="vlanCheckbox" onChange={() => setVlan(!vlan)}>
-            Use Default Management VLAN
-          </Checkbox>
+          <Checkbox data-testid="vlanCheckbox">Use Default Management VLAN</Checkbox>
         </Item>
-
-        {!vlan && (
-          <Item
-            wrapperCol={{ offset: 5, span: 15 }}
-            name="vlan"
-            rules={[
-              {
-                required: !vlan,
-                message: 'Vlan expected between 2 and 4095',
-              },
-              ({ getFieldValue }) => ({
-                validator(_rule, value) {
-                  if (!value || (getFieldValue('vlan') <= 4095 && getFieldValue('vlan') > 1)) {
-                    return Promise.resolve();
-                  }
-                  return Promise.reject(new Error('Vlan expected between 2 and 4095'));
-                },
-              }),
-            ]}
-            hasFeedback
-          >
-            <Input
-              data-testid="vlanInput"
-              className={globalStyles.field}
-              placeholder="2-4095"
-              type="number"
-              min={2}
-              max={4095}
-              maxLength={4}
-            />
-          </Item>
-        )}
-
+        <Item
+          noStyle
+          shouldUpdate={(prevValues, currentValues) =>
+            prevValues.vlanNative !== currentValues.vlanNative
+          }
+        >
+          {({ getFieldValue }) => {
+            return (
+              !getFieldValue('vlanNative') && (
+                <Item
+                  wrapperCol={{ offset: 5, span: 15 }}
+                  name="vlan"
+                  rules={[
+                    {
+                      required: true,
+                      message: 'Vlan expected between 2 and 4095',
+                    },
+                    () => ({
+                      validator(_rule, value) {
+                        if (
+                          !value ||
+                          (getFieldValue('vlan') <= 4095 && getFieldValue('vlan') > 1)
+                        ) {
+                          return Promise.resolve();
+                        }
+                        return Promise.reject(new Error('Vlan expected between 2 and 4095'));
+                      },
+                    }),
+                  ]}
+                  hasFeedback
+                >
+                  <Input
+                    data-testid="vlanInput"
+                    className={globalStyles.field}
+                    placeholder="2-4095"
+                    type="number"
+                    min={2}
+                    max={4095}
+                    maxLength={4}
+                  />
+                </Item>
+              )
+            );
+          }}
+        </Item>
         <Item label="NTP" name={['ntpServer', 'auto']} valuePropName="checked">
-          <Checkbox data-testid="ntpCheckbox" onChange={() => setNTP(!ntp)}>
-            Use Default Servers
-          </Checkbox>
+          <Checkbox data-testid="ntpCheckbox">Use Default Servers</Checkbox>
         </Item>
-        {!ntp && (
-          <Item wrapperCol={{ offset: 5, span: 15 }}>
-            <Item
-              name={['ntpServer', 'value']}
-              rules={[{ required: !ntp, message: 'Please enter your NTP server' }]}
-            >
-              <Input className={globalStyles.field} placeholder="Enter NTP server" />
-            </Item>
-          </Item>
-        )}
+        <Item
+          noStyle
+          shouldUpdate={(prevValues, currentValues) =>
+            prevValues.ntpServer?.auto !== currentValues.ntpServer?.auto
+          }
+        >
+          {({ getFieldValue }) => {
+            return (
+              !getFieldValue(['ntpServer', 'auto']) && (
+                <>
+                  <Item
+                    rules={[
+                      {
+                        validator: validateNtpServer,
+                      },
+                    ]}
+                    wrapperCol={{ offset: 5, span: 15 }}
+                    validateStatus={ntpServerValidation.status}
+                    help={ntpServerValidation.help}
+                  >
+                    <Input.Search
+                      placeholder="Enter NTP server..."
+                      enterButton="Add"
+                      onSearch={handleOnAddServer}
+                      value={ntpServerSearch}
+                      onChange={handleOnChangeNtpServer}
+                    />
+                  </Item>
+                  <List
+                    className={styles.List}
+                    itemLayout="horizontal"
+                    dataSource={ntpServers}
+                    locale={{
+                      emptyText: (
+                        <Empty
+                          image={Empty.PRESENTED_IMAGE_SIMPLE}
+                          description={
+                            <span>
+                              <span>
+                                No Data Visible.
+                                <br />
+                                Please enter at least 1 NTP server or use default servers.
+                              </span>
+                            </span>
+                          }
+                        />
+                      ),
+                    }}
+                    renderItem={item => (
+                      <List.Item
+                        extra={
+                          <Button type="danger" onClick={() => handleOnDeleteServer(item)}>
+                            Remove
+                          </Button>
+                        }
+                      >
+                        <List.Item.Meta title={item} />
+                      </List.Item>
+                    )}
+                  />
+                  <Item name={['ntpServer', 'value']} hidden>
+                    <Input />
+                  </Item>
+                </>
+              )
+            );
+          }}
+        </Item>
         <Item label="LED Status" name="ledControlEnabled" valuePropName="checked">
           <Checkbox disabled>Show LED indicators on APs</Checkbox>
         </Item>
-
         <Item
           label="RTLS"
           name={['rtlsSettings', 'enabled']}
@@ -252,65 +392,72 @@ const AccessPointForm = ({
           ]}
         >
           <Radio.Group disabled>
-            <Radio value="false" onChange={() => setRtls(false)}>
-              Disabled
-            </Radio>
-            <Radio value="true" onChange={() => setRtls(true)}>
-              Enabled
-            </Radio>
+            <Radio value="false">Disabled</Radio>
+            <Radio value="true">Enabled</Radio>
           </Radio.Group>
         </Item>
-        {rtls && (
-          <>
-            <Item
-              data-testid="rtlsInputFields"
-              wrapperCol={{ offset: 5, span: 15 }}
-              name={['rtlsSettings', 'srvHostIp']}
-              rules={[
-                {
-                  required: rtls,
-                  pattern: IP_REGEX,
-                  message: 'Enter in the format [0-255].[0-255].[0-255].[0-255]',
-                },
-              ]}
-              hasFeedback
-            >
-              <Input
-                className={globalStyles.field}
-                placeholder="IP Address"
-                data-testid="svrIpAdress"
-              />
-            </Item>
-            <Item
-              wrapperCol={{ offset: 5, span: 15 }}
-              name={['rtlsSettings', 'srvHostPort']}
-              rules={[
-                {
-                  required: rtls,
-                  message: 'Port expected between 1 - 65535',
-                },
-                ({ getFieldValue }) => ({
-                  validator(_rule, value) {
-                    if (!value || getFieldValue(['rtlsSettings', 'srvHostPort']) < 65535) {
-                      return Promise.resolve();
-                    }
-                    return Promise.reject(new Error('Port expected between 1 - 65535'));
-                  },
-                }),
-              ]}
-              hasFeedback
-            >
-              <Input
-                className={globalStyles.field}
-                placeholder="Port"
-                type="number"
-                min={1}
-                max={65535}
-                data-testid="svrPort"
-              />
-            </Item>
-          </>
-        )}
+        <Item
+          noStyle
+          shouldUpdate={(prevValues, currentValues) =>
+            prevValues.rtlsSettings?.enabled !== currentValues.tlsSettings?.enabled
+          }
+        >
+          {({ getFieldValue }) => {
+            return (
+              getFieldValue(['rtlsSettings', 'enabled']) === 'true' && (
+                <>
+                  <Item
+                    data-testid="rtlsInputFields"
+                    wrapperCol={{ offset: 5, span: 15 }}
+                    name={['rtlsSettings', 'srvHostIp']}
+                    rules={[
+                      {
+                        required: true,
+                        pattern: IP_REGEX,
+                        message: 'Enter in the format [0-255].[0-255].[0-255].[0-255]',
+                      },
+                    ]}
+                    hasFeedback
+                  >
+                    <Input
+                      className={globalStyles.field}
+                      placeholder="IP Address"
+                      data-testid="svrIpAdress"
+                    />
+                  </Item>
+                  <Item
+                    wrapperCol={{ offset: 5, span: 15 }}
+                    name={['rtlsSettings', 'srvHostPort']}
+                    rules={[
+                      {
+                        required: true,
+                        message: 'Port expected between 1 - 65535',
+                      },
+                      () => ({
+                        validator(_rule, value) {
+                          if (!value || getFieldValue(['rtlsSettings', 'srvHostPort']) < 65535) {
+                            return Promise.resolve();
+                          }
+                          return Promise.reject(new Error('Port expected between 1 - 65535'));
+                        },
+                      }),
+                    ]}
+                    hasFeedback
+                  >
+                    <Input
+                      className={globalStyles.field}
+                      placeholder="Port"
+                      type="number"
+                      min={1}
+                      max={65535}
+                      data-testid="svrPort"
+                    />
+                  </Item>
+                </>
+              )
+            );
+          }}
+        </Item>
         <Item
           label="Syslog"
           name={['syslogRelay', 'enabled']}
@@ -322,86 +469,94 @@ const AccessPointForm = ({
           ]}
         >
           <Radio.Group>
-            <Radio value="false" onChange={() => setSyslog(false)}>
-              Disabled
-            </Radio>
-            <Radio value="true" onChange={() => setSyslog(true)}>
-              Enabled
-            </Radio>
+            <Radio value="false">Disabled</Radio>
+            <Radio value="true">Enabled</Radio>
           </Radio.Group>
         </Item>
-        {syslog && (
-          <>
-            <Item data-testid="syslogInputFields" wrapperCol={{ offset: 5, span: 15 }}>
-              <div className={styles.InlineDiv}>
-                <Item
-                  name={['syslogRelay', 'srvHostIp']}
-                  rules={[
-                    {
-                      required: syslog,
-                      pattern: IP_REGEX,
-                      message: 'Enter in the format [0-255].[0-255].[0-255].[0-255]',
-                    },
-                  ]}
-                  hasFeedback
-                >
-                  <Input className={globalStyles.field} placeholder="IP Address" />
-                </Item>
-                <Item
-                  name={['syslogRelay', 'srvHostPort']}
-                  rules={[
-                    {
-                      required: syslog,
-                      message: 'Port expected between 1 - 65535',
-                    },
-                    ({ getFieldValue }) => ({
-                      validator(_rule, value) {
-                        if (!value || getFieldValue(['syslogRelay', 'srvHostPort']) < 65535) {
-                          return Promise.resolve();
-                        }
-                        return Promise.reject(new Error('Port expected between 1 - 65535'));
+        <Item
+          noStyle
+          shouldUpdate={(prevValues, currentValues) =>
+            prevValues.syslogRelay?.enabled !== currentValues.syslogRelay?.enabled
+          }
+        >
+          {({ getFieldValue }) => {
+            return (
+              getFieldValue(['syslogRelay', 'enabled']) === 'true' && (
+                <>
+                  <Item data-testid="syslogInputFields" wrapperCol={{ offset: 5, span: 15 }}>
+                    <div className={styles.InlineDiv}>
+                      <Item
+                        name={['syslogRelay', 'srvHostIp']}
+                        rules={[
+                          {
+                            required: true,
+                            pattern: IP_REGEX,
+                            message: 'Enter in the format [0-255].[0-255].[0-255].[0-255]',
+                          },
+                        ]}
+                        hasFeedback
+                      >
+                        <Input className={globalStyles.field} placeholder="IP Address" />
+                      </Item>
+                      <Item
+                        name={['syslogRelay', 'srvHostPort']}
+                        rules={[
+                          {
+                            required: true,
+                            message: 'Port expected between 1 - 65535',
+                          },
+                          () => ({
+                            validator(_rule, value) {
+                              if (!value || getFieldValue(['syslogRelay', 'srvHostPort']) < 65535) {
+                                return Promise.resolve();
+                              }
+                              return Promise.reject(new Error('Port expected between 1 - 65535'));
+                            },
+                          }),
+                        ]}
+                        hasFeedback
+                      >
+                        <Input
+                          className={globalStyles.field}
+                          placeholder="Port"
+                          type="number"
+                          min={1}
+                          max={65535}
+                        />
+                      </Item>
+                    </div>
+                  </Item>
+                  <Item
+                    wrapperCol={{ offset: 5, span: 15 }}
+                    name={['syslogRelay', 'severity']}
+                    rules={[
+                      {
+                        required: true,
+                        message: 'Please select the Syslog mode',
                       },
-                    }),
-                  ]}
-                  hasFeedback
-                >
-                  <Input
-                    className={globalStyles.field}
-                    placeholder="Port"
-                    type="number"
-                    min={1}
-                    max={65535}
-                  />
-                </Item>
-              </div>
-            </Item>
-            <Item
-              wrapperCol={{ offset: 5, span: 15 }}
-              name={['syslogRelay', 'severity']}
-              rules={[
-                {
-                  required: true,
-                  message: 'Please select the Syslog mode',
-                },
-              ]}
-            >
-              <Select
-                data-testid="select"
-                className={globalStyles.field}
-                placeholder="Select Syslog Mode"
-              >
-                <Option value="DEBUG">Debug (DEBUG)</Option>
-                <Option value="INFO">Info. (INFO)</Option>
-                <Option value="NOTICE">Notice (NOTICE)</Option>
-                <Option value="WARNING">Warning (WARNING)</Option>
-                <Option value="ERR">Error (ERR)</Option>
-                <Option value="CRIT">Critical (CRIT)</Option>
-                <Option value="ALERT">Alert (ALERT)</Option>
-                <Option value="EMERG">Emergency (EMERG)</Option>
-              </Select>
-            </Item>
-          </>
-        )}
+                    ]}
+                  >
+                    <Select
+                      data-testid="select"
+                      className={globalStyles.field}
+                      placeholder="Select Syslog Mode"
+                    >
+                      <Option value="DEBUG">Debug (DEBUG)</Option>
+                      <Option value="INFO">Info. (INFO)</Option>
+                      <Option value="NOTICE">Notice (NOTICE)</Option>
+                      <Option value="WARNING">Warning (WARNING)</Option>
+                      <Option value="ERR">Error (ERR)</Option>
+                      <Option value="CRIT">Critical (CRIT)</Option>
+                      <Option value="ALERT">Alert (ALERT)</Option>
+                      <Option value="EMERG">Emergency (EMERG)</Option>
+                    </Select>
+                  </Item>
+                </>
+              )
+            );
+          }}
+        </Item>
+
         <Item
           label="Synthetic Client"
           name="syntheticClientEnabled"

--- a/src/containers/ProfileDetails/components/AccessPoint/index.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/index.js
@@ -32,7 +32,9 @@ const AccessPointForm = ({
 
   const [greModalVisible, setGreModalVisible] = useState(false);
   const [greList, setGreList] = useState(details?.greTunnelConfigurations || []);
-  const [ntpServers, setNtpServers] = useState([]);
+  const [ntpServers, setNtpServers] = useState(
+    !details?.ntpServer?.auto ? details?.ntpServer?.value?.split(':') : []
+  );
   const [ntpServerSearch, setNtpServerSearch] = useState('');
   const [ntpServerValidation, setNtpServerValidation] = useState({});
 
@@ -80,7 +82,6 @@ const AccessPointForm = ({
       vlan: details?.vlan || defaultApProfile.vlan,
       ntpServer: {
         auto: details?.ntpServer?.auto ?? defaultApProfile.ntpServer.auto,
-        value: details?.ntpServer?.value ?? defaultApProfile.ntpServer.value,
       },
       ledControlEnabled: details?.ledControlEnabled || defaultApProfile.ledControlEnabled,
       rtlsSettings: {
@@ -98,7 +99,6 @@ const AccessPointForm = ({
       syntheticClientEnabled: details?.syntheticClientEnabled ? 'true' : 'false',
       rfProfileId: currentRfId,
     });
-    setNtpServers(details?.ntpServer?.value?.split(':'));
   }, [form, details]);
 
   useEffect(() => {
@@ -338,38 +338,25 @@ const AccessPointForm = ({
                       onChange={handleOnChangeNtpServer}
                     />
                   </Item>
-                  <List
-                    className={styles.List}
-                    itemLayout="horizontal"
-                    dataSource={ntpServers}
-                    locale={{
-                      emptyText: (
-                        <Empty
-                          image={Empty.PRESENTED_IMAGE_SIMPLE}
-                          description={
-                            <span>
-                              <span>
-                                No Data Visible.
-                                <br />
-                                Please enter at least 1 NTP server or use default servers.
-                              </span>
-                            </span>
+                  {ntpServers?.length > 0 && (
+                    <List
+                      className={styles.List}
+                      itemLayout="horizontal"
+                      dataSource={ntpServers}
+                      renderItem={item => (
+                        <List.Item
+                          extra={
+                            <Button type="danger" onClick={() => handleOnDeleteServer(item)}>
+                              Remove
+                            </Button>
                           }
-                        />
-                      ),
-                    }}
-                    renderItem={item => (
-                      <List.Item
-                        extra={
-                          <Button type="danger" onClick={() => handleOnDeleteServer(item)}>
-                            Remove
-                          </Button>
-                        }
-                      >
-                        <List.Item.Meta title={item} />
-                      </List.Item>
-                    )}
-                  />
+                        >
+                          <List.Item.Meta title={item} />
+                        </List.Item>
+                      )}
+                    />
+                  )}
+
                   <Item name={['ntpServer', 'value']} hidden>
                     <Input />
                   </Item>

--- a/src/containers/ProfileDetails/components/CaptivePortal/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/index.js
@@ -714,7 +714,7 @@ const CaptivePortalForm = ({
 
           {whitelist.length > 0 && (
             <List
-              className={styles.Whitelist}
+              className={styles.List}
               itemLayout="horizontal"
               dataSource={whitelist}
               renderItem={item => (

--- a/src/containers/ProfileDetails/components/index.module.scss
+++ b/src/containers/ProfileDetails/components/index.module.scss
@@ -114,12 +114,13 @@
   justify-content: flex-end;
 }
 
-.Whitelist {
-  margin-left: 16.66666667%;
+.List {
+  margin-left: 22%;
   max-width: 50%;
-
+  word-wrap: break-word;
   &:global(.ant-list) {
     padding: 0;
+    margin-bottom: 20px;
   }
 }
 

--- a/src/containers/ProfileDetails/index.js
+++ b/src/containers/ProfileDetails/index.js
@@ -126,6 +126,14 @@ const ProfileDetails = ({
             });
             return;
           }
+
+          if (!values.ntpServer.auto && !values.ntpServer.value) {
+            notification.error({
+              message: 'Error',
+              description: 'At least 1 NTP Server is required.',
+            });
+            return;
+          }
           formattedData.childProfileIds.push(values.rfProfileId);
           formattedData = Object.assign(formattedData, formatApProfileForm(values));
         }


### PR DESCRIPTION
JIRA: [WIFI-2056](https://telecominfraproject.atlassian.net/browse/WIFI-2056)

## Description
*Summary of this PR*
-Added support for multiple NTP servers in AP profile
-Cleaned up AP profile by removing unused states

### Before this PR
*Screenshots of what it looked like before this PR*
Multiple NTP Servers were supported but the UI wasn't helpful on what delimiters to use or the maximum length: 
![image](https://user-images.githubusercontent.com/55258316/115911720-6ab26000-a43c-11eb-9772-d6fd8076b6d3.png)

### After this PR
*Screenshots of what it will look like after this PR*
List of NTP servers with input validation:
![image](https://user-images.githubusercontent.com/55258316/115911818-903f6980-a43c-11eb-9555-06b3bb12467d.png)
