### PR TITLE
hotfix: syncing up create & edit profiles error notifications

### DIFF
--- a/src/containers/AddProfile/index.js
+++ b/src/containers/AddProfile/index.js
@@ -102,6 +102,20 @@ const AddProfile = ({
         let formattedData = { ...values };
 
         if (profileType === PROFILES.ssid) {
+          if (
+            (values.secureMode === 'wpaRadius' ||
+              values.secureMode === 'wpa2Radius' ||
+              values.secureMode === 'wpa2OnlyRadius' ||
+              values.secureMode === 'wpa3OnlyEAP' ||
+              values.secureMode === 'wpa3MixedEAP') &&
+            (!values?.radiusServiceId?.value || !values?.radiusServiceId?.label)
+          ) {
+            notification.error({
+              message: 'Error',
+              description: 'A RADIUS Profile is required.',
+            });
+            return;
+          }
           formattedData.model_type = 'SsidConfiguration';
           formattedData = Object.assign(formattedData, formatSsidProfileForm(values));
         }
@@ -125,6 +139,16 @@ const AddProfile = ({
         }
 
         if (profileType === PROFILES.captivePortal) {
+          if (
+            values.authenticationType === 'radius' &&
+            (!values?.radiusServiceId?.value || !values?.radiusServiceId?.label)
+          ) {
+            notification.error({
+              message: 'Error',
+              description: 'RADIUS Profile is required for authentication.',
+            });
+            return;
+          }
           formattedData.model_type = 'CaptivePortalConfiguration';
           formattedData = Object.assign(
             formattedData,
@@ -164,7 +188,7 @@ const AddProfile = ({
             });
             return;
           }
-          if (!values.osuSsidProfileId) {
+          if (!values.osuSsidProfileId?.value || !values.osuSsidProfileId?.label) {
             notification.error({
               message: 'Error',
               description: 'An SSID Profile is required.',

--- a/src/containers/ProfileDetails/index.js
+++ b/src/containers/ProfileDetails/index.js
@@ -112,7 +112,7 @@ const ProfileDetails = ({
           ) {
             notification.error({
               message: 'Error',
-              description: 'At least 1 RADIUS Profile is required.',
+              description: 'A RADIUS Profile is required.',
             });
             return;
           }
@@ -177,7 +177,7 @@ const ProfileDetails = ({
             });
             return;
           }
-          if (!values.osuSsidProfileId) {
+          if (!values.osuSsidProfileId?.value || !values.osuSsidProfileId?.label) {
             notification.error({
               message: 'Error',
               description: 'An SSID Profile is required.',


### PR DESCRIPTION
JIRA: NO JIRA

## Description
*Summary of this PR*
bug: error messages related to child profiles were inconsistent for creating profiles compared to editing profiles. IE a required RADIUS profile when creating isn't required in editing or vice versa. 

solution: synced them up so that it should be the same now.
-also fixed the error notification for required OSU SSID in passpoint profiles due to `osuSsidProfileId` changing into an object

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*