### PR TITLE
WIFI-2078: NAS ID and NAS IP should only appear for 802.1x Radius Auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tip-wlan/wlan-cloud-ui-library",
-  "version": "1.1.10",
+  "version": "1.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -561,178 +561,173 @@ const SSIDForm = ({
           }}
         </Item>
       </Card>
-      <Card title="RADIUS">
-        {(mode === 'wpaRadius' ||
-          mode === 'wpa2Radius' ||
-          mode === 'wpa2OnlyRadius' ||
-          mode === 'wpa3OnlyEAP' ||
-          mode === 'wpa3MixedEAP') && (
-          <>
-            <Item
-              name="radiusServiceId"
-              label="RADIUS Profile"
-              rules={[
-                {
-                  required: true,
-                  message: 'Please select a RADIUS profile',
-                },
-              ]}
-            >
-              <Select
-                className={globalStyles.field}
-                placeholder="Select RADIUS Profile"
-                onPopupScroll={e => onFetchMoreProfiles(e, PROFILES.radius)}
-                showSearch={onSearchProfile}
-                filterOption={false}
-                onSearch={name => onSearchProfile(PROFILES.radius, name)}
-                onSelect={() => onSearchProfile && onSearchProfile(PROFILES.radius)}
-                loading={loadingRadiusProfiles}
-                notFoundContent={!loadingRadiusProfiles && <Empty />}
-                labelInValue
-              >
-                {radiusProfiles.map(profile => (
-                  <Option key={profile.id} value={profile.id}>
-                    {profile.name}
-                  </Option>
-                ))}
-              </Select>
-            </Item>
-            <Item
-              name="radiusAcountingServiceInterval"
-              label="RADIUS Accounting Interval"
-              rules={[
-                {
-                  required: true,
-                  message: 'Please enter a RADIUS accounting interval',
-                },
-                () => ({
-                  validator(_rule, value) {
-                    if (!value || (value >= 60 && value <= 600) || value === '0') {
-                      return Promise.resolve();
-                    }
-                    return Promise.reject(new Error('0 or 60 - 600'));
-                  },
-                }),
-              ]}
-            >
-              <Input
-                className={globalStyles.field}
-                placeholder="0 or 60 - 600 "
-                type="number"
-                min={60}
-                max={600}
-                addonAfter={
-                  <Tooltip
-                    title="Interval can be 0 or a number between 60 and 600"
-                    text="Seconds"
-                  />
-                }
-              />
-            </Item>
-          </>
-        )}
-        <Item
-          label="NAS ID"
-          name={['radiusClientConfiguration', 'nasClientId']}
-          rules={[
-            {
-              required: true,
-              message: 'Please select NAS ID',
-            },
-          ]}
-        >
-          <Select
-            data-testid="securityMode"
-            className={globalStyles.field}
-            placeholder="Select NAS ID"
+      {(mode === 'wpaRadius' ||
+        mode === 'wpa2Radius' ||
+        mode === 'wpa2OnlyRadius' ||
+        mode === 'wpa3OnlyEAP' ||
+        mode === 'wpa3MixedEAP') && (
+        <Card title="RADIUS">
+          <Item
+            name="radiusServiceId"
+            label="RADIUS Profile"
+            rules={[
+              {
+                required: true,
+                message: 'Please select a RADIUS profile',
+              },
+            ]}
           >
-            <Option value="BSSID">BSSID</Option>
-            <Option value="AP_BASE_MAC">AP Base MAC Address</Option>
-            <Option value="USER_DEFINED">Manual</Option>
-          </Select>
-        </Item>
-        <Item
-          noStyle
-          shouldUpdate={(prevValues, currentValues) =>
-            prevValues.radiusClientConfiguration?.nasClientId !==
-            currentValues.radiusClientConfiguration?.nasClientId
-          }
-        >
-          {({ getFieldValue }) => {
-            return (
-              getFieldValue(['radiusClientConfiguration', 'nasClientId']) === 'USER_DEFINED' && (
-                <Item
-                  wrapperCol={{ offset: 5, span: 15 }}
-                  name={['radiusClientConfiguration', 'userDefinedNasId']}
-                  rules={[
-                    {
-                      required: true,
-                      message: 'Please enter NAS ID',
-                    },
-                    {
-                      pattern: /^\s*(?:\S\s*){3,}$/,
-                      message: 'NAS-ID must be atleast 3 characters',
-                    },
-                  ]}
-                >
-                  <Input className={globalStyles.field} placeholder="Enter NAS ID" />
-                </Item>
-              )
-            );
-          }}
-        </Item>
-        <Item
-          label="NAS IP"
-          name={['radiusClientConfiguration', 'nasClientIp']}
-          rules={[
-            {
-              required: true,
-              message: 'Please select NAS IP',
-            },
-          ]}
-        >
-          <Select
-            data-testid="securityMode"
-            className={globalStyles.field}
-            placeholder="Select NAS IP"
+            <Select
+              className={globalStyles.field}
+              placeholder="Select RADIUS Profile"
+              onPopupScroll={e => onFetchMoreProfiles(e, PROFILES.radius)}
+              showSearch={onSearchProfile}
+              filterOption={false}
+              onSearch={name => onSearchProfile(PROFILES.radius, name)}
+              onSelect={() => onSearchProfile && onSearchProfile(PROFILES.radius)}
+              loading={loadingRadiusProfiles}
+              notFoundContent={!loadingRadiusProfiles && <Empty />}
+              labelInValue
+            >
+              {radiusProfiles.map(profile => (
+                <Option key={profile.id} value={profile.id}>
+                  {profile.name}
+                </Option>
+              ))}
+            </Select>
+          </Item>
+          <Item
+            name="radiusAcountingServiceInterval"
+            label="RADIUS Accounting Interval"
+            rules={[
+              {
+                required: true,
+                message: 'Please enter a RADIUS accounting interval',
+              },
+              () => ({
+                validator(_rule, value) {
+                  if (!value || (value >= 60 && value <= 600) || value === '0') {
+                    return Promise.resolve();
+                  }
+                  return Promise.reject(new Error('0 or 60 - 600'));
+                },
+              }),
+            ]}
           >
-            <Option value="WAN_IP">WAN</Option>
-            <Option value="PROXY_IP">Proxy</Option>
-            <Option value="USER_DEFINED">Manual</Option>
-          </Select>
-        </Item>
-        <Item
-          noStyle
-          shouldUpdate={(prevValues, currentValues) =>
-            prevValues.radiusClientConfiguration?.nasClientIp !==
-            currentValues.radiusClientConfiguration?.nasClientIp
-          }
-        >
-          {({ getFieldValue }) => {
-            return (
-              getFieldValue(['radiusClientConfiguration', 'nasClientIp']) === 'USER_DEFINED' && (
-                <Item
-                  wrapperCol={{ offset: 5, span: 15 }}
-                  name={['radiusClientConfiguration', 'userDefinedNasIp']}
-                  hasFeedback
-                  rules={[
-                    {
-                      required: true,
-                      message: 'Please enter NAS IP',
-                    },
-                    {
-                      pattern: IP_REGEX,
-                      message: 'Enter in the format [0-255].[0-255].[0-255].[0-255]',
-                    },
-                  ]}
-                >
-                  <Input className={globalStyles.field} placeholder="Enter NAS IP" />
-                </Item>
-              )
-            );
-          }}
-        </Item>
-      </Card>
+            <Input
+              className={globalStyles.field}
+              placeholder="0 or 60 - 600 "
+              type="number"
+              min={60}
+              max={600}
+              addonAfter={
+                <Tooltip title="Interval can be 0 or a number between 60 and 600" text="Seconds" />
+              }
+            />
+          </Item>
+          <Item
+            label="NAS ID"
+            name={['radiusClientConfiguration', 'nasClientId']}
+            rules={[
+              {
+                required: true,
+                message: 'Please select NAS ID',
+              },
+            ]}
+          >
+            <Select
+              data-testid="securityMode"
+              className={globalStyles.field}
+              placeholder="Select NAS ID"
+            >
+              <Option value="BSSID">BSSID</Option>
+              <Option value="AP_BASE_MAC">AP Base MAC Address</Option>
+              <Option value="USER_DEFINED">Manual</Option>
+            </Select>
+          </Item>
+          <Item
+            noStyle
+            shouldUpdate={(prevValues, currentValues) =>
+              prevValues.radiusClientConfiguration?.nasClientId !==
+              currentValues.radiusClientConfiguration?.nasClientId
+            }
+          >
+            {({ getFieldValue }) => {
+              return (
+                getFieldValue(['radiusClientConfiguration', 'nasClientId']) === 'USER_DEFINED' && (
+                  <Item
+                    wrapperCol={{ offset: 5, span: 15 }}
+                    name={['radiusClientConfiguration', 'userDefinedNasId']}
+                    rules={[
+                      {
+                        required: true,
+                        message: 'Please enter NAS ID',
+                      },
+                      {
+                        pattern: /^\s*(?:\S\s*){3,}$/,
+                        message: 'NAS-ID must be atleast 3 characters',
+                      },
+                    ]}
+                  >
+                    <Input className={globalStyles.field} placeholder="Enter NAS ID" />
+                  </Item>
+                )
+              );
+            }}
+          </Item>
+          <Item
+            label="NAS IP"
+            name={['radiusClientConfiguration', 'nasClientIp']}
+            rules={[
+              {
+                required: true,
+                message: 'Please select NAS IP',
+              },
+            ]}
+          >
+            <Select
+              data-testid="securityMode"
+              className={globalStyles.field}
+              placeholder="Select NAS IP"
+            >
+              <Option value="WAN_IP">WAN</Option>
+              <Option value="PROXY_IP">Proxy</Option>
+              <Option value="USER_DEFINED">Manual</Option>
+            </Select>
+          </Item>
+          <Item
+            noStyle
+            shouldUpdate={(prevValues, currentValues) =>
+              prevValues.radiusClientConfiguration?.nasClientIp !==
+              currentValues.radiusClientConfiguration?.nasClientIp
+            }
+          >
+            {({ getFieldValue }) => {
+              return (
+                getFieldValue(['radiusClientConfiguration', 'nasClientIp']) === 'USER_DEFINED' && (
+                  <Item
+                    wrapperCol={{ offset: 5, span: 15 }}
+                    name={['radiusClientConfiguration', 'userDefinedNasIp']}
+                    hasFeedback
+                    rules={[
+                      {
+                        required: true,
+                        message: 'Please enter NAS IP',
+                      },
+                      {
+                        pattern: IP_REGEX,
+                        message: 'Enter in the format [0-255].[0-255].[0-255].[0-255]',
+                      },
+                    ]}
+                  >
+                    <Input className={globalStyles.field} placeholder="Enter NAS IP" />
+                  </Item>
+                )
+              );
+            }}
+          </Item>
+        </Card>
+      )}
 
       <Card title="Roaming">
         <Item label="Advanced Settings" colon={false}>


### PR DESCRIPTION
JIRA: [WIFI-2078](https://telecominfraproject.atlassian.net/browse/WIFI-2078)

## Description
*Summary of this PR*
bug: the NAS IP and NAS ID should only be available when the mode is Enterprise along with configured Radius

solution: made the Radius Card only available when the mode is one of Enterprise options 

### Before this PR
*Screenshots of what it looked like before this PR*
![Screen Shot 2021-04-28 at 3 12 40 PM](https://user-images.githubusercontent.com/70719869/116460737-5fdd3e00-a835-11eb-9249-45a3e9dd20af.png)
![Screen Shot 2021-04-28 at 3 12 50 PM](https://user-images.githubusercontent.com/70719869/116460749-64095b80-a835-11eb-9818-59f98a58d8ae.png)


### After this PR
*Screenshots of what it will look like after this PR*
![Screen Shot 2021-04-28 at 3 10 55 PM](https://user-images.githubusercontent.com/70719869/116460700-53f17c00-a835-11eb-818e-43c34844b421.png)
![Screen Shot 2021-04-28 at 3 11 08 PM](https://user-images.githubusercontent.com/70719869/116460706-5653d600-a835-11eb-8456-674995103c57.png)
