### PR TITLE
bugfix/WIFI-1438: removed auto as 80211x option

### DIFF
--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -7,7 +7,7 @@ import ThemeContext from 'contexts/ThemeContext';
 import globalStyles from 'styles/index.scss';
 import styles from '../index.module.scss';
 import { defaultSsidProfile } from '../constants';
-import { RADIOS, ROAMING, PROFILES, IP_REGEX } from '../../constants/index';
+import { RADIOS, ROAMING, DEFAULT_ROAMING, PROFILES, IP_REGEX } from '../../constants/index';
 
 const { Item } = Form;
 const { Option } = Select;
@@ -35,7 +35,6 @@ const SSIDForm = ({
 
   const dropdownOptions = (
     <Select className={globalStyles.field}>
-      <Option value="auto">Auto</Option>
       <Option value="true">Enabled</Option>
       <Option value="false">Disabled</Option>
     </Select>
@@ -46,7 +45,8 @@ const SSIDForm = ({
 
     RADIOS.forEach(i => {
       ROAMING.forEach(j => {
-        radioBasedValues[`${j}${i}`] = details?.radioBasedConfigs?.[i]?.[j]?.toString() ?? 'auto';
+        radioBasedValues[`${j}${i}`] =
+          details?.radioBasedConfigs?.[i]?.[j]?.toString() ?? DEFAULT_ROAMING[j];
       });
     });
 

--- a/src/containers/ProfileDetails/constants/index.js
+++ b/src/containers/ProfileDetails/constants/index.js
@@ -1,5 +1,10 @@
 export const RADIOS = ['is2dot4GHz', 'is5GHz', 'is5GHzU', 'is5GHzL'];
 export const ROAMING = ['enable80211r', 'enable80211k', 'enable80211v'];
+export const DEFAULT_ROAMING = {
+  enable80211r: 'false',
+  enable80211k: 'true',
+  enable80211v: 'true',
+};
 export const DEFAULT_NTP_SERVER = 'pool.ntp.org';
 export const DEFAULT_HESS_ID = '00:00:00:00:00:00';
 


### PR DESCRIPTION
JIRA: [WIFI-1438](https://telecominfraproject.atlassian.net/browse/WIFI-1438)

## Description
*Summary of this PR*
bug: `802.11r/k/v` are boolean values and no longer support `auto` as an option

solution: removed auto as an option and as a default value, added the following Default values described in the JIRA ticket:
- 802.11r: Disabled
- 802.11k: Enabled
- 802.11v: Enabled

### Before this PR
*Screenshots of what it looked like before this PR*
when mode is personal
![Screen Shot 2021-04-28 at 4 01 36 PM](https://user-images.githubusercontent.com/70719869/116465992-f6146280-a83b-11eb-952c-8a7ef3d7e047.png)
when mode is enterprise
![Screen Shot 2021-04-28 at 4 01 22 PM](https://user-images.githubusercontent.com/70719869/116466075-0cbab980-a83c-11eb-90f5-29c0ed1caa22.png)


### After this PR
*Screenshots of what it will look like after this PR*
when mode is personal 
![Screen Shot 2021-04-28 at 4 00 59 PM](https://user-images.githubusercontent.com/70719869/116466113-1ba16c00-a83c-11eb-8761-c7fb06ab4caa.png)
when mode is enterprise
![Screen Shot 2021-04-28 at 4 01 12 PM](https://user-images.githubusercontent.com/70719869/116466157-24923d80-a83c-11eb-8a29-eb938b39620a.png)

