### PR TITLE
bugfix/WIFI-2152: Changed 802.11r default roaming setting

### DIFF
--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -25,6 +25,7 @@ const SSIDForm = ({
 }) => {
   const { radioTypes } = useContext(ThemeContext);
   const [mode, setMode] = useState(details.secureMode || defaultSsidProfile.secureMode);
+  const [modeChanged, setModeChanged] = useState(false);
 
   const hexadecimalRegex = e => {
     const re = /[0-9A-F:]+/g;
@@ -95,6 +96,29 @@ const SSIDForm = ({
       },
     });
   }, [form, details]);
+
+  const handleOnModeChanged = () => {
+    if (!modeChanged) {
+      setModeChanged(true);
+    }
+  };
+
+  useEffect(() => {
+    if (modeChanged) {
+      const radioBasedValues = {};
+      RADIOS.forEach(i => {
+        radioBasedValues[`enable80211r${i}`] =
+          mode === 'wpa3OnlyEAP' ||
+          mode === 'wpa3MixedEAP' ||
+          mode === 'wpa2OnlyRadius' ||
+          mode === 'wpa2Radius' ||
+          mode === 'wpaRadius'
+            ? 'true'
+            : 'false';
+      });
+      form.setFieldsValue({ ...radioBasedValues });
+    }
+  }, [mode, modeChanged]);
 
   return (
     <div className={styles.ProfilePage}>
@@ -458,7 +482,10 @@ const SSIDForm = ({
           <Select
             data-testid="securityMode"
             className={globalStyles.field}
-            onChange={value => setMode(value)}
+            onChange={value => {
+              setMode(value);
+              handleOnModeChanged();
+            }}
             placeholder="Select Security and Encryption Mode"
           >
             <Option value="wpa3OnlyEAP">WPA3 Enterprise</Option>


### PR DESCRIPTION
JIRA: [WIFI-2152](https://telecominfraproject.atlassian.net/browse/WIFI-2152)

## Description
*Summary of this PR*

- When switching to an enterprise security mode, the default value for 802.11r roaming is now `enabled` instead of `disabled`
- The comment regarding removing the "Auto" option was already done in the [SDK-profile cleanup](https://github.com/Telecominfraproject/wlan-cloud-ui-library/pull/232)

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*