### PR TITLE
bugfix/WIFI-2414: Added validation to roamingOI field

### DIFF
--- a/src/containers/ProfileDetails/components/ProviderId/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/ProviderId/tests/index.test.js
@@ -23,9 +23,6 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
-const generateRandomHex = size =>
-  [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
-
 describe('<ProviderIdForm />', () => {
   it('should work when roaming oi is null', async () => {
     const ProviderIdFormComp = () => {
@@ -103,7 +100,8 @@ describe('<ProviderIdForm />', () => {
       expect(getByText(errorMsg)).toBeVisible();
     });
 
-    fireEvent.change(input, { target: { value: generateRandomHex(8) } });
+    // all faker hexaDecimal values are prepended by "0x" which the OI regex does not support
+    fireEvent.change(input, { target: { value: faker.random.hexaDecimal(8).substring(2) } });
 
     await waitFor(() => {
       expect(queryByText(errorMsg)).not.toBeInTheDocument();
@@ -122,7 +120,8 @@ describe('<ProviderIdForm />', () => {
     const { getByText, getByPlaceholderText } = render(<ProviderIdFormComp />);
 
     const errorMsg = 'Enter a unique OI';
-    const hexString = generateRandomHex(8);
+    // all faker hexaDecimal values are prepended by "0x" which the OI regex does not support
+    const hexString = faker.random.hexaDecimal(8).substring(2);
 
     fireEvent.click(getByText(/add roaming oi/i));
     const input = getByPlaceholderText('Enter OI 1');

--- a/src/containers/ProfileDetails/components/ProviderId/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/ProviderId/tests/index.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, waitFor, act } from '@testing-library/react';
+import faker from 'faker';
 import { Form } from 'antd';
 import { render } from 'tests/utils';
 
@@ -22,6 +23,9 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
+const generateRandomHex = size =>
+  [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
+
 describe('<ProviderIdForm />', () => {
   it('should work when roaming oi is null', async () => {
     const ProviderIdFormComp = () => {
@@ -33,6 +37,104 @@ describe('<ProviderIdForm />', () => {
       );
     };
     render(<ProviderIdFormComp />);
+  });
+
+  it('Clicking Add Roaming OI should add the first OI input to the form', async () => {
+    const ProviderIdFormComp = () => {
+      const [form] = Form.useForm();
+      return (
+        <Form form={form}>
+          <ProviderIdForm details={mockProviderId} form={form} />
+        </Form>
+      );
+    };
+    const { getByText, getByPlaceholderText } = render(<ProviderIdFormComp />);
+
+    fireEvent.click(getByText(/add roaming oi/i));
+
+    await waitFor(() => {
+      expect(getByPlaceholderText('Enter OI 1')).toBeVisible();
+    });
+  });
+
+  it('Clicking the delete OI button should remove the associated OI input from the form', async () => {
+    const ProviderIdFormComp = () => {
+      const [form] = Form.useForm();
+      return (
+        <Form form={form}>
+          <ProviderIdForm details={mockProviderId} form={form} />
+        </Form>
+      );
+    };
+    const { getByText, getByPlaceholderText, getByTestId } = render(<ProviderIdFormComp />);
+
+    fireEvent.click(getByText(/add roaming oi/i));
+
+    const input = getByPlaceholderText('Enter OI 1');
+    await waitFor(() => {
+      expect(input).toBeVisible();
+    });
+
+    fireEvent.click(getByTestId('removeRoamingOI0'));
+
+    await waitFor(() => {
+      expect(input).not.toBeInTheDocument();
+    });
+  });
+
+  it('Error message should show if Roaming OI is not between 3 and 15 octets and configured as a hexstring', async () => {
+    const ProviderIdFormComp = () => {
+      const [form] = Form.useForm();
+      return (
+        <Form form={form}>
+          <ProviderIdForm details={mockProviderId} form={form} />
+        </Form>
+      );
+    };
+    const { getByText, getByPlaceholderText, queryByText } = render(<ProviderIdFormComp />);
+
+    fireEvent.click(getByText(/add roaming oi/i));
+
+    const input = getByPlaceholderText('Enter OI 1');
+    fireEvent.change(input, { target: { value: faker.internet.userName() } });
+
+    const errorMsg = 'Each OI must be between 3 and 15 octets and configured as a hexstring';
+    await waitFor(() => {
+      expect(getByText(errorMsg)).toBeVisible();
+    });
+
+    fireEvent.change(input, { target: { value: generateRandomHex(8) } });
+
+    await waitFor(() => {
+      expect(queryByText(errorMsg)).not.toBeInTheDocument();
+    });
+  });
+
+  it('Error message should show if Roaming OI is duplicated', async () => {
+    const ProviderIdFormComp = () => {
+      const [form] = Form.useForm();
+      return (
+        <Form form={form}>
+          <ProviderIdForm details={mockProviderId} form={form} />
+        </Form>
+      );
+    };
+    const { getByText, getByPlaceholderText } = render(<ProviderIdFormComp />);
+
+    const errorMsg = 'Enter a unique OI';
+    const hexString = generateRandomHex(8);
+
+    fireEvent.click(getByText(/add roaming oi/i));
+    const input = getByPlaceholderText('Enter OI 1');
+    fireEvent.change(input, { target: { value: hexString } });
+
+    fireEvent.click(getByText(/add roaming oi/i));
+    const input2 = getByPlaceholderText('Enter OI 2');
+    fireEvent.change(input2, { target: { value: hexString } });
+
+    await waitFor(() => {
+      expect(getByText(errorMsg)).toBeVisible();
+    });
   });
 
   it('should add a new PLMN to the table', async () => {

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -331,7 +331,6 @@ export const formatPasspointForm = (values, details) => {
 
 export const formatProviderProfileForm = values => {
   const formattedData = { ...values };
-  formattedData.roamingOi = values.roamingOi.replace(/\s/g, '').split(',');
 
   if (!formattedData.osuServerUri) {
     formattedData.osuServerUri = '';


### PR DESCRIPTION
JIRA: [WIFI-2414](https://telecominfraproject.atlassian.net/browse/WIFI-2414)

## Description
*Summary of this PR*

- Added validation to roamingOI field so that each sub-element in the field must be 3-15 octets in length (octet is a pair of hex characters, e.g. A3), and no duplicate elements can be inputted
- Improved UI of field to make it a dynamic list instead of a comma separated input field

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/119893501-71376a00-bf09-11eb-9d70-a3333d897e09.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/119893447-5ebd3080-bf09-11eb-9c03-8b913b088fc0.png)
