### PR TITLE
feature/WIFI-2423: RADIUS Proxy info in Status tab

### DIFF
--- a/src/containers/AccessPointDetails/components/Status/index.js
+++ b/src/containers/AccessPointDetails/components/Status/index.js
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
-import { Card, Form, Table } from 'antd';
+import { Card, Form, Table, Tag } from 'antd';
+import { CheckCircleOutlined, InfoCircleOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types';
 import ThemeContext from 'contexts/ThemeContext';
 import { sortRadioTypes } from 'utils/sortRadioTypes';
@@ -78,7 +79,36 @@ const Status = ({ data, showAlarms, extraFields }) => {
   return (
     <>
       <Form {...layout}>
-        <Card title="Status">
+        <Card title="System">
+          <p>RADIUS Proxy:</p>
+          <Item label="Status">
+            {status?.protocol?.detailsJSON?.isApcConnected ? (
+              <Tag color="success" icon={<CheckCircleOutlined />}>
+                Connected
+              </Tag>
+            ) : (
+              <Tag color="warning" icon={<InfoCircleOutlined />}>
+                Disconnected
+              </Tag>
+            )}
+          </Item>
+          {status?.protocol?.detailsJSON?.isApcConnected && (
+            <>
+              <Item label="Mode">
+                <Tag>{status?.protocol?.detailsJSON?.apcMode ?? 'N/A'}</Tag>
+              </Item>
+              <Item label="Designated Proxy">
+                <Tag>{status?.protocol?.detailsJSON?.apcDesignatedRouterIpAddress ?? 'N/A'}</Tag>
+              </Item>
+              <Item label="Backup Proxy">
+                <Tag>
+                  {status?.protocol?.detailsJSON?.apcBackupDesignatedRouterIpAddress ?? 'N/A'}
+                </Tag>
+              </Item>
+            </>
+          )}
+        </Card>
+        <Card title="Radio">
           {renderSpanItem(' ', radioMap, 'radioType')}
           {renderSpanItem('Channel', status?.channel?.detailsJSON?.channelNumberStatusDataMap)}
           {renderSpanItem('Noise Floor', status?.radioUtilization?.detailsJSON?.avgNoiseFloor)}


### PR DESCRIPTION
JIRA: [WIFI-2423](https://telecominfraproject.atlassian.net/browse/WIFI-2423)

## Description
*Summary of this PR*
Added RADIUS Proxy details to Access Point Details > Status Tab

- Added a new card called System which will show the RADIUS Proxy details
- Renamed old "Status" card to "Radio"

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/120368630-49b51880-c2e0-11eb-9745-1209053a5578.png)


### After this PR
*Screenshots of what it will look like after this PR*
Connected Status:
![image](https://user-images.githubusercontent.com/55258316/120368424-0d81b800-c2e0-11eb-808f-b157abd960f3.png)

Disconnected Status:
![image](https://user-images.githubusercontent.com/55258316/120368812-85e87900-c2e0-11eb-9951-baab140bc591.png)
