### PR TITLE
bugfix/WIFI-2522: Fixed RADIUS Proxy cert upload

### DIFF
--- a/src/containers/ProfileDetails/components/AccessPoint/index.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/index.js
@@ -1020,7 +1020,7 @@ const AccessPointForm = ({
                           >
                             <Upload
                               data-testid={`caCertFile${field.key}`}
-                              accept="application/x-x509-ca-cert"
+                              accept=".pem"
                               fileList={certFiles?.[`caCert${field.key}`]}
                               beforeUpload={handleFileUpload}
                               onChange={({ fileList }) =>
@@ -1047,7 +1047,7 @@ const AccessPointForm = ({
                           >
                             <Upload
                               data-testid={`clientCertFile${field.key}`}
-                              accept="application/x-x509-ca-cert"
+                              accept=".pem"
                               fileList={certFiles?.[`clientCert${field.key}`]}
                               beforeUpload={handleFileUpload}
                               onChange={({ fileList }) =>


### PR DESCRIPTION
JIRA: [WIFI-2522](https://telecominfraproject.atlassian.net/browse/WIFI-2522)

## Description
*Summary of this PR*
Fixed file upload `accept` condition for RADIUS Proxy certifications

- `accept="application/x-x509-ca-cert"` is not supported on Firefox or Safari
- Verified on Safari, Firefox and Chrome that using `accept=".pem"` works

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*