### PR TITLE
bugfix/WIFI-2545: Removed unsupported rates for 5G radio

### DIFF
--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -549,14 +549,18 @@ const General = ({
             renderOptionItem,
             {
               mapName: 'advancedRadioMap',
-              dropdown: (
+              dropdown: key => (
                 <Select className={styles.Field}>
-                  <Option value="rate1mbps">1</Option>
-                  <Option value="rate2mbps">2</Option>
-                  <Option value="rate5dot5mbps">5.5</Option>
+                  {key === 'is2dot4GHz' && (
+                    <>
+                      <Option value="rate1mbps">1</Option>
+                      <Option value="rate2mbps">2</Option>
+                      <Option value="rate5dot5mbps">5.5</Option>
+                    </>
+                  )}
                   <Option value="rate6mbps">6</Option>
                   <Option value="rate9mbps">9</Option>
-                  <Option value="rate11mbps">11</Option>
+                  {key === 'is2dot4GHz' && <Option value="rate11mbps">11</Option>}
                   <Option value="rate12mbps">12</Option>
                   <Option value="rate18mbps">18</Option>
                   <Option value="rate24mbps">24</Option>


### PR DESCRIPTION
JIRA: [WIFI-2545](https://telecominfraproject.atlassian.net/browse/WIFI-2545)

## Description
*Summary of this PR*
Removed unsupported management rates for 5G radio in AP Details Inventory page

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/121093971-d9b10180-c7bb-11eb-8445-1a402c4eae8a.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/121094026-ef262b80-c7bb-11eb-900e-e641c7966407.png)
