### PR TITLE
bugfix/WIFI-2661: Fixed phrasing for Network Mode disclaimer

### DIFF
--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -327,7 +327,7 @@ const SSIDForm = ({
                       <Radio value="usePortal">Use</Radio>
                     </RadioGroup>
                   ) : (
-                    <span className={styles.Disclaimer}>Not Applicable</span>
+                    <span className={styles.Disclaimer}>Requires NAT Mode</span>
                   )}
                 </Item>
               </>

--- a/src/containers/ProfileDetails/components/index.module.scss
+++ b/src/containers/ProfileDetails/components/index.module.scss
@@ -66,7 +66,6 @@
   margin-right: 5px;
   margin-bottom: 5px;
   font-style: italic;
-  font-size: 10px;
 }
 
 .infoCard {


### PR DESCRIPTION
JIRA: [WIFI-2661)](https://telecominfraproject.atlassian.net/browse/WIFI-2661)

## Description
*Summary of this PR*

- Changed wording from "Captive Portal : Not Applicable" to "Captive Portal : Requires NAT Mode" 
- Made font size for disclaimer 12px to make it consistent with rest of form

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/121934111-e4681b00-cd14-11eb-956e-1fef0e278684.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/121934093-db774980-cd14-11eb-9b40-7f3e0d109e28.png)
