### PR TITLE
hotfix/ProfilesTableStyling: Fixed table overflow bug

### DIFF
--- a/src/containers/AutoProvision/index.js
+++ b/src/containers/AutoProvision/index.js
@@ -126,7 +126,6 @@ const AutoProvision = ({
     },
     {
       title: '',
-      dataIndex: '',
       key: 'editModel',
       width: 60,
       render: (_, record) => (
@@ -145,7 +144,6 @@ const AutoProvision = ({
 
     {
       title: '',
-      dataIndex: '',
       key: 'deleteModel',
       width: 60,
       render: (_, record) => {
@@ -268,7 +266,13 @@ const AutoProvision = ({
               }
             >
               <div className={styles.Content}>
-                <Table rowKey="model" columns={columns} dataSource={tableData} pagination={false} />
+                <Table
+                  scroll={{ x: 'max-content' }}
+                  rowKey="model"
+                  columns={columns}
+                  dataSource={tableData}
+                  pagination={false}
+                />
               </div>
             </Card>
           </div>

--- a/src/containers/BlockedList/index.js
+++ b/src/containers/BlockedList/index.js
@@ -86,7 +86,13 @@ const BlockedList = ({ data, onUpdateClient, onAddClient }) => {
           </RoleProtectedBtn>
         </Header>
 
-        <Table rowKey="macAddress" dataSource={data} columns={columns} pagination={false} />
+        <Table
+          scroll={{ x: 'max-content' }}
+          rowKey="macAddress"
+          dataSource={data}
+          columns={columns}
+          pagination={false}
+        />
       </div>
     </Container>
   );

--- a/src/containers/Firmware/index.js
+++ b/src/containers/Firmware/index.js
@@ -144,7 +144,6 @@ const Firmware = ({
 
     {
       title: '',
-      dataIndex: '',
       key: 'editAssignment',
       width: 60,
       render: (_, record) => (
@@ -162,7 +161,6 @@ const Firmware = ({
     },
     {
       title: '',
-      dataIndex: '',
       key: 'deleteAssignment',
       width: 60,
       render: (_, record) => (
@@ -221,7 +219,6 @@ const Firmware = ({
     },
     {
       title: '',
-      dataIndex: '',
       key: 'editFirmware',
       width: 60,
       render: (_, record) => (
@@ -239,7 +236,6 @@ const Firmware = ({
     },
     {
       title: '',
-      dataIndex: '',
       key: 'deleteFirmware',
       width: 60,
       render: (_, record) => {
@@ -327,6 +323,7 @@ const Firmware = ({
       </Header>
       {trackAssignmentReady && (
         <Table
+          scroll={{ x: 'max-content' }}
           rowKey={i => i.modelId + i.firmwareVersionRecordId}
           columns={assignmentColumns}
           dataSource={trackAssignmentData}
@@ -352,7 +349,13 @@ const Firmware = ({
         )}
       </Header>
       {firmwareReady && (
-        <Table rowKey="id" columns={versionColumn} dataSource={firmwareData} pagination={false} />
+        <Table
+          scroll={{ x: 'max-content' }}
+          rowKey="id"
+          columns={versionColumn}
+          dataSource={firmwareData}
+          pagination={false}
+        />
       )}
       {firmwareLoading && (
         <Spin className={styles.spinner} size="large" data-testid="firmwareSpinner" />

--- a/src/containers/Profile/index.js
+++ b/src/containers/Profile/index.js
@@ -36,10 +36,9 @@ const Profile = ({ data, onReload, onLoadMore, isLastPage, onDeleteProfile }) =>
     {
       title: 'ACCESS POINTS',
       dataIndex: 'equipmentCount',
-      width: 700,
+      width: 600,
     },
     {
-      title: '',
       width: 80,
       render: (_, record) => (
         <DeleteButton
@@ -63,7 +62,7 @@ const Profile = ({ data, onReload, onLoadMore, isLastPage, onDeleteProfile }) =>
 
   return (
     <Container>
-      <div className={styles.Profile}>
+      <div>
         <Header>
           <h1>Profiles</h1>
           <div className={styles.Buttons}>
@@ -76,9 +75,9 @@ const Profile = ({ data, onReload, onLoadMore, isLastPage, onDeleteProfile }) =>
           </div>
         </Header>
         <Table
+          scroll={{ x: 'max-content' }}
           rowClassName={styles.Row}
           rowKey="id"
-          className={styles.Profile}
           dataSource={data}
           columns={columns}
           pagination={false}

--- a/src/containers/ProfileDetails/components/CaptivePortal/components/Users/index.js
+++ b/src/containers/ProfileDetails/components/CaptivePortal/components/Users/index.js
@@ -124,7 +124,13 @@ const Users = ({ userList, handleAddUser, handleUpdateUser, handleDeleteUser }) 
         title="User List"
         extra={<RoleProtectedBtn onClick={() => setAddUserModal(true)}> Add User</RoleProtectedBtn>}
       >
-        <Table rowKey="username" columns={columns} dataSource={userList} pagination={false} />
+        <Table
+          scroll={{ x: 'max-content' }}
+          rowKey="username"
+          columns={columns}
+          dataSource={userList}
+          pagination={false}
+        />
       </Card>
     </>
   );

--- a/src/containers/ProfileDetails/components/PasspointProfile/index.js
+++ b/src/containers/ProfileDetails/components/PasspointProfile/index.js
@@ -502,6 +502,7 @@ const PasspointProfileForm = ({
           </Button>
         </Item>
         <Table
+          scroll={{ x: 'max-content' }}
           dataSource={connectionCapabilitySetList}
           columns={columns}
           pagination={false}

--- a/src/containers/ProfileDetails/components/ProviderId/components/NaiRealm/index.js
+++ b/src/containers/ProfileDetails/components/ProviderId/components/NaiRealm/index.js
@@ -139,6 +139,7 @@ const NaiRealm = ({ eapMap, form, addEap, removeEap }) => {
         }
       >
         <Table
+          scroll={{ x: 'max-content' }}
           dataSource={formatRealmList}
           columns={columnsNai}
           pagination={false}


### PR DESCRIPTION
NO-JIRA

## Description
*Summary of this PR*

- Any table that had a column with a preassigned width would not resize properly and would break out of the container
- Fixed all instances of this by adding `scroll={{ x: 'max-content' }}` as a prop

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/121958912-23f13000-cd32-11eb-9266-a90dca9918e3.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/121958842-1045c980-cd32-11eb-9350-46caf565df35.png)
