### PR TITLE
bugfix/WIFI-2673: Fixed EAP method dropdown on Passpoint Provider profile

### DIFF
--- a/src/containers/ProfileDetails/components/ProviderId/components/NaiRealm/index.js
+++ b/src/containers/ProfileDetails/components/ProviderId/components/NaiRealm/index.js
@@ -4,6 +4,7 @@ import { Card, Form, Cascader, Table, Select as AntdSelect } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import Modal from 'components/Modal';
 import { Select, Input, RoleProtectedBtn } from 'components/WithRoles';
+import ContainedSelect from 'components/ContainedSelect';
 import _ from 'lodash';
 import { authOptions } from './constants';
 
@@ -163,7 +164,7 @@ const NaiRealm = ({ eapMap, form, addEap, removeEap }) => {
                   },
                 ]}
               >
-                <Select placeholder="Please select" data-testid="method">
+                <ContainedSelect placeholder="Please select" data-testid="method">
                   <Option value="EAP-TLS with certificate" data-testid="eapCertificate">
                     EAP-TLS with certificate
                   </Option>
@@ -175,7 +176,7 @@ const NaiRealm = ({ eapMap, form, addEap, removeEap }) => {
                   </Option>
                   <Option value="EAP-AKA Authentication">EAP-AKA Authentication</Option>
                   <Option value="EAP-AKA'">EAP-AKA Prime</Option>
-                </Select>
+                </ContainedSelect>
               </Item>
               <Item
                 name="auth"

--- a/src/containers/ProfileDetails/constants/index.js
+++ b/src/containers/ProfileDetails/constants/index.js
@@ -2,13 +2,6 @@ export const RADIOS = ['is2dot4GHz', 'is5GHz', 'is5GHzU', 'is5GHzL'];
 export const ROAMING = ['enable80211r', 'enable80211k', 'enable80211v'];
 export const DEFAULT_NTP_SERVER = 'pool.ntp.org';
 export const DEFAULT_HESS_ID = '00:00:00:00:00:00';
-export const EAP_METHODS = {
-  'EAP-TLS with certificate': ' eap_tls',
-  'EAP-TTLS with username/password': 'eap_ttls',
-  'EAP-AKA Authentication': 'eap_aka_authentication',
-  'EAP-MSCHAP-V2 with username/password': 'eap_mschap_v2',
-  'EAP-AKA': 'eap_aka',
-};
 
 export const IP_REGEX = /^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])(\.(?!$)|$)){4}$/;
 

--- a/src/containers/ProfileDetails/constants/index.js
+++ b/src/containers/ProfileDetails/constants/index.js
@@ -2,6 +2,13 @@ export const RADIOS = ['is2dot4GHz', 'is5GHz', 'is5GHzU', 'is5GHzL'];
 export const ROAMING = ['enable80211r', 'enable80211k', 'enable80211v'];
 export const DEFAULT_NTP_SERVER = 'pool.ntp.org';
 export const DEFAULT_HESS_ID = '00:00:00:00:00:00';
+export const EAP_METHODS = {
+  'EAP-TLS with certificate': ' eap_tls',
+  'EAP-TTLS with username/password': 'eap_ttls',
+  'EAP-AKA Authentication': 'eap_aka_authentication',
+  'EAP-MSCHAP-V2 with username/password': 'eap_mschap_v2',
+  'EAP-AKA': 'eap_aka',
+};
 
 export const IP_REGEX = /^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])(\.(?!$)|$)){4}$/;
 

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -3,6 +3,7 @@ import {
   ROAMING,
   DEFAULT_NTP_SERVER,
   DEFAULT_HESS_ID,
+  EAP_METHODS,
 } from '../containers/ProfileDetails/constants/index';
 
 export const formatFile = file => {
@@ -356,6 +357,7 @@ export const formatProviderProfileForm = values => {
         naiRealms: formattedData.naiRealms.replace(/\s/g, '').split(',') || [],
         eapMap: formattedData.eapMap || {},
         encoding: formattedData.encoding || 0,
+        eapMethods: Object.keys(formattedData.eapMap).map(i => EAP_METHODS[i]),
       },
     ];
   }

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -3,7 +3,6 @@ import {
   ROAMING,
   DEFAULT_NTP_SERVER,
   DEFAULT_HESS_ID,
-  EAP_METHODS,
 } from '../containers/ProfileDetails/constants/index';
 
 export const formatFile = file => {
@@ -357,7 +356,7 @@ export const formatProviderProfileForm = values => {
         naiRealms: formattedData.naiRealms.replace(/\s/g, '').split(',') || [],
         eapMap: formattedData.eapMap || {},
         encoding: formattedData.encoding || 0,
-        eapMethods: Object.keys(formattedData.eapMap).map(i => EAP_METHODS[i]),
+        eapMethods: Object.keys(formattedData.eapMap),
       },
     ];
   }


### PR DESCRIPTION
JIRA: [WIFI-2673](https://telecominfraproject.atlassian.net/browse/WIFI-2673)

## Description
*Summary of this PR*

- Fixed Select Dropdown that would not show options in Passpoint Provider Profile.  Fixed this by using the `ContainedSelect` component which uses the Antd prop `getPopupContainer` to fix the scrolling behaviour. 
- Correctly filled out the `eapMethods` attribute in the `naiRealmList` object

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/122107297-ef8c7b00-cde8-11eb-8117-86ade7ecd194.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/122107232-da175100-cde8-11eb-940f-f26b21645dd7.png)
