### PR TITLE
bugfix/WIFI-2524: Removed rule for Certificate Passphrase field

### DIFF
--- a/src/containers/ProfileDetails/components/AccessPoint/index.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/index.js
@@ -1122,16 +1122,7 @@ const AccessPointForm = ({
                               <Button icon={<UploadOutlined />}>Click to Upload</Button>
                             </Upload>
                           </Item>
-                          <Item
-                            name={[field.name, 'passphrase']}
-                            label="Certificate Passphrase"
-                            rules={[
-                              {
-                                required: true,
-                                message: 'Certificate Passphrase is required',
-                              },
-                            ]}
-                          >
+                          <Item name={[field.name, 'passphrase']} label="Certificate Passphrase">
                             <Password placeholder="Enter Passphrase" />
                           </Item>
                         </>

--- a/src/containers/ProfileDetails/components/SSID/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/SSID/tests/index.test.js
@@ -303,28 +303,6 @@ describe('<SSIDForm />', () => {
     });
   });
 
-  it('changing Mode select option should update Roaming card', async () => {
-    const SSIDFormComp = () => {
-      const [form] = Form.useForm();
-      return (
-        <Form form={form}>
-          <SSIDForm {...mockSsid} form={form} />
-        </Form>
-      );
-    };
-
-    const { getByText, container } = render(<SSIDFormComp />);
-
-    const selectMode = container.querySelector('[data-testid=securityMode] > .ant-select-selector');
-    fireEvent.mouseDown(selectMode);
-    fireEvent.keyDown(selectMode, DOWN_ARROW);
-    await waitForElement(() => getByText('Open (No Encryption)'));
-    fireEvent.click(getByText('Open (No Encryption)'));
-    await waitFor(() => {
-      expect(getByText('802.11k')).toBeVisible();
-    });
-  });
-
   it('changing Mode select option to WPA & WPA2 Personal (mixed mode) should update Roaming card', async () => {
     const mockDetails = {
       ...mockSsid.details,

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -158,6 +158,8 @@ export const formatApProfileForm = values => {
             }
           : null,
         passphrase: useRadSec ? config.passphrase : null,
+        sharedSecret: !useRadSec ? config.sharedSecret : null,
+        acctSharedSecret: !useRadSec ? config.acctSharedSecret : null,
         dynamicDiscovery: config.realm.some(i => i === '*') ? config.dynamicDiscovery : false,
         ...(!useAccounting && { acctPort: null, acctServer: null, acctSharedSecret: null }),
       });


### PR DESCRIPTION
JIRA: [WIFI-2524](https://telecominfraproject.atlassian.net/browse/WIFI-2524)

## Description
*Summary of this PR*

- Removed required rule for Certificate Passphrase field
- Fixed bug where values for`sharedSecret` and `acctSharedSecret` were still passed in when `useRadSec` was enabled

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/122960958-ee5fce80-d351-11eb-9041-c8b136c5ba2f.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/122960877-d9833b00-d351-11eb-81ff-71241eca82af.png)
