### PR TITLE
hotfix/ScrollToTop: Added ScrollToTop  component

### DIFF
--- a/src/components/ScrollToTop/index.js
+++ b/src/components/ScrollToTop/index.js
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/components/ScrollToTop/index.js
+++ b/src/components/ScrollToTop/index.js
@@ -1,9 +1,10 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
 const ScrollToTop = () => {
   const { pathname } = useLocation();
-  useEffect(() => {
+
+  useLayoutEffect(() => {
     window.scrollTo(0, 0);
   }, [pathname]);
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ export { default as Header } from 'components/Header';
 export { default as Container } from 'components/Container';
 export { default as DeleteButton } from 'components/DeleteButton';
 export { default as Tooltip } from 'components/Tooltip';
+export { default as ScrollToTop } from 'components/ScrollToTop';
 export { default as LineGraphTooltip } from 'components/GraphTooltips/LineGraphTooltip';
 export { default as PieGraphTooltip } from 'components/GraphTooltips/PieGraphTooltip';
 


### PR DESCRIPTION
NO-JIRA 

## Description
*Summary of this PR*
Throughout the site, when there is a  long content page, it stays scrolled down when navigated to if the previous page was also scrolled. Fixed this by adding a `ScrollToTop` component that resets the scroll upon route change.

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*