### PR TITLE
bugfix/WIFI-2532: Removed required rule for proxy certs files

### DIFF
--- a/src/containers/ProfileDetails/components/AccessPoint/index.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/index.js
@@ -53,7 +53,7 @@ const AccessPointForm = ({
 
   const [greModalVisible, setGreModalVisible] = useState(false);
   const [greList, setGreList] = useState(details?.greTunnelConfigurations || []);
-  const [ntpServers, setNtpServers] = useState(setInitialNtpServer());
+  const [ntpServers, setNtpServers] = useState();
   const [ntpServerSearch, setNtpServerSearch] = useState('');
   const [ntpServerValidation, setNtpServerValidation] = useState({});
 
@@ -149,6 +149,8 @@ const AccessPointForm = ({
         clientKey: config.clientKey ? { file: formatFile(config.clientKey) } : null,
       })),
     });
+
+    setNtpServers(setInitialNtpServer());
   }, [form, details]);
 
   useEffect(() => {
@@ -1077,12 +1079,6 @@ const AccessPointForm = ({
                           <Item
                             name={[field.name, 'clientCert']}
                             label="Client Certification"
-                            rules={[
-                              {
-                                required: true,
-                                message: 'Client Certification file is required',
-                              },
-                            ]}
                             tooltip="PEM File"
                           >
                             <Upload
@@ -1104,12 +1100,6 @@ const AccessPointForm = ({
                           <Item
                             name={[field.name, 'clientKey']}
                             label="Client Key"
-                            rules={[
-                              {
-                                required: true,
-                                message: 'Client Key file is required',
-                              },
-                            ]}
                             tooltip="KEY File"
                           >
                             <Upload

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -130,7 +130,6 @@ export const formatApProfileForm = values => {
     formattedData.radiusProxyConfigurations = [];
     values.radiusProxyConfigurations.forEach((config, index) => {
       const useRadSec = isBool(config.useRadSec);
-
       const { useAccounting } = config;
       formattedData.radiusProxyConfigurations.push({
         ...config,
@@ -143,20 +142,22 @@ export const formatApProfileForm = values => {
               fileCategory: 'RadSecAuthentication',
             }
           : null,
-        clientCert: useRadSec
-          ? {
-              apExportUrl: config.clientCert.file.name,
-              fileType: 'PEM',
-              fileCategory: 'RadSecAuthentication',
-            }
-          : null,
-        clientKey: useRadSec
-          ? {
-              apExportUrl: config.clientKey.file.name,
-              fileType: 'KEY',
-              fileCategory: 'RadSecAuthentication',
-            }
-          : null,
+        clientCert:
+          useRadSec && config.clientCert
+            ? {
+                apExportUrl: config.clientCert.file.name,
+                fileType: 'PEM',
+                fileCategory: 'RadSecAuthentication',
+              }
+            : null,
+        clientKey:
+          useRadSec && config.clientKey
+            ? {
+                apExportUrl: config.clientKey.file.name,
+                fileType: 'KEY',
+                fileCategory: 'RadSecAuthentication',
+              }
+            : null,
         passphrase: useRadSec ? config.passphrase : null,
         sharedSecret: !useRadSec ? config.sharedSecret : null,
         acctSharedSecret: !useRadSec ? config.acctSharedSecret : null,


### PR DESCRIPTION
JIRA: [WIFI-2532](https://telecominfraproject.atlassian.net/browse/WIFI-2532)

## Description
*Summary of this PR*
Removed required rule for `Client Certification` and `Client Key` files. Only the `CA Cert` file is now required when `RADSEC` is enabled

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/123140538-664af900-d425-11eb-9cab-b97f5b3af033.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/123140449-4d424800-d425-11eb-90e6-20320d015483.png)
