### PR TITLE
bugfix/WIFI-2727: Validation for radio channels

### DIFF
--- a/src/containers/AccessPointDetails/components/General/constants.js
+++ b/src/containers/AccessPointDetails/components/General/constants.js
@@ -12,3 +12,10 @@ export const USER_FRIENDLY_RATES = {
   rate48mbps: '48',
   rate54mbps: '54',
 };
+
+export const ALLOWED_CHANNELS_STEP = {
+  is20MHz: 1,
+  is40MHz: 2,
+  is80MHz: 4,
+  is160MHz: 8,
+};

--- a/src/containers/AccessPointDetails/components/General/constants.js
+++ b/src/containers/AccessPointDetails/components/General/constants.js
@@ -19,3 +19,7 @@ export const ALLOWED_CHANNELS_STEP = {
   is80MHz: 4,
   is160MHz: 8,
 };
+
+export const MAX_CHANNEL_WIDTH_40MHZ_OR_80MHZ = 157;
+
+export const MAX_CHANNEL_WIDTH_160MHZ = 100;

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -18,7 +18,12 @@ import Tooltip from 'components/Tooltip';
 
 import { sortRadioTypes } from 'utils/sortRadioTypes';
 import { pageLayout } from 'utils/form';
-import { USER_FRIENDLY_RATES, ALLOWED_CHANNELS_STEP } from './constants';
+import {
+  USER_FRIENDLY_RATES,
+  ALLOWED_CHANNELS_STEP,
+  MAX_CHANNEL_WIDTH_40MHZ_OR_80MHZ,
+  MAX_CHANNEL_WIDTH_160MHZ,
+} from './constants';
 
 import styles from '../../index.module.scss';
 
@@ -388,12 +393,13 @@ const General = ({
               .sort((a, b) => a - b)
               .filter((__, index) => index % ALLOWED_CHANNELS_STEP[bandwidth] === 0);
 
-            if (allowedChannels.length % 2 !== 0 && key !== 'is2dot4GHz') {
-              allowedChannels = allowedChannels.slice(0, -1);
-            }
-
-            if (bandwidth === 'is160MHz') {
-              allowedChannels = allowedChannels.filter(item => item <= 100);
+            if (bandwidth !== 'is20MHz') {
+              allowedChannels = allowedChannels.filter(item => {
+                if (bandwidth === 'is160MHz') {
+                  return item <= MAX_CHANNEL_WIDTH_160MHZ;
+                }
+                return item <= MAX_CHANNEL_WIDTH_40MHZ_OR_80MHZ;
+              });
             }
 
             return (

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -423,19 +423,7 @@ const General = ({
                         getFieldValue(['radioMap', key, channel.dataIndex]),
                         10
                       );
-                      let dfs = false;
-                      if (
-                        !value ||
-                        powerLevels.some(item => {
-                          dfs = item.dfs;
-                          return item.channelNumber === channelNumber;
-                        })
-                      ) {
-                        if (dfs) {
-                          return Promise.reject(
-                            new Error(`A DFS channel is not allowed as a backup channel`)
-                          );
-                        }
+                      if (!value || allowedChannels.includes(channelNumber)) {
                         return Promise.resolve();
                       }
                       return Promise.reject(
@@ -449,8 +437,8 @@ const General = ({
                   className={styles.Field}
                   placeholder={`Enter ${label} for ${radioTypes[key]}`}
                   type="number"
-                  min={1}
-                  max={165}
+                  min={Math.min(...allowedChannels)}
+                  max={Math.max(...allowedChannels)}
                   addonAfter={channel.addOnText}
                   disabled={isEnabled}
                 />

--- a/src/containers/AccessPointDetails/components/General/tests/index.test.js
+++ b/src/containers/AccessPointDetails/components/General/tests/index.test.js
@@ -344,7 +344,7 @@ describe('<General />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('1 - 165')).toBeVisible();
+      expect(getByText(/allowed channels:/i)).toBeVisible();
     });
   });
 
@@ -358,7 +358,7 @@ describe('<General />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('1 - 165')).toBeVisible();
+      expect(getByText(/allowed channels:/i)).toBeVisible();
     });
   });
 


### PR DESCRIPTION
JIRA: [WIFI-2727](https://telecominfraproject.atlassian.net/browse/WIFI-2727)

## Description
*Summary of this PR*

Added validation for Radio Channels:
For both 2.4GHz and 5Ghz: 
-Added list of allowed channels which will be used to validate if input is valid 

For 5Ghz: 
- Added check so that DFS channel should not be allowed as Backup Channel for 5GHz Radio
- Added check to dynamically update allowed channels based on rf-profile bandwidth 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/123170307-5db7ea00-d448-11eb-8eaf-c28a85644e70.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/123172806-ab822180-d44b-11eb-9458-2f446afa207f.png)
