### PR TITLE
bugfix/WIFI-2031: Proxy-ARP field for SSID profile

### DIFF
--- a/src/containers/Dashboard/components/LineChart/index.js
+++ b/src/containers/Dashboard/components/LineChart/index.js
@@ -53,7 +53,7 @@ const MyLineChart = ({ title, data, options, refreshAfter }) => {
     });
 
     if (firstTs && lastTs) {
-      return formatTicks(firstTs, lastTs, 5);
+      return formatTicks(firstTs, lastTs, 4);
     }
     return [];
   }, [lineData]);

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -98,6 +98,9 @@ const SSIDForm = ({
       },
       useRadiusProxy:
         details?.useRadiusProxy?.toString() ?? defaultSsidProfile.useRadiusProxy.toString(),
+      enableProxyArpForHotspot:
+        details?.enableProxyArpForHotspot?.toString() ??
+        defaultSsidProfile.enableProxyArpForHotspot.toString(),
     });
   }, [form, details]);
 
@@ -471,6 +474,9 @@ const SSIDForm = ({
               </Item>
             );
           }}
+        </Item>
+        <Item name="enableProxyArpForHotspot" label="Proxy-ARP">
+          {radioOptions}
         </Item>
       </Card>
 

--- a/src/containers/ProfileDetails/components/constants.js
+++ b/src/containers/ProfileDetails/components/constants.js
@@ -262,6 +262,7 @@ const defaultSsidProfile = {
     nasOperatorId: null,
   },
   useRadiusProxy: false,
+  enableProxyArpForHotspot: false,
 };
 const defaultApProfile = {
   model_type: 'ApNetworkConfiguration',


### PR DESCRIPTION
JIRA: [WIFI-2031](https://telecominfraproject.atlassian.net/browse/WIFI-2031)

## Description
*Summary of this PR*
Added Proxy-ARP field to SSID profile - field is disabled by default. 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/123282463-85ef2980-d4d8-11eb-863e-be8b0865d185.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/123282407-796ad100-d4d8-11eb-9b98-315ae9af9f71.png)
