### PR TITLE
hotfix/RadioSortOrder: Changed radio sort order

### DIFF
--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -6,6 +6,7 @@ import Tooltip from 'components/Tooltip';
 import ThemeContext from 'contexts/ThemeContext';
 
 import globalStyles from 'styles/index.scss';
+import { sortRadioTypes } from 'utils/sortRadioTypes';
 import styles from '../index.module.scss';
 import { defaultSsidProfile } from '../constants';
 import { RADIOS, ROAMING, PROFILES, IP_REGEX } from '../../constants/index';
@@ -35,6 +36,8 @@ const SSIDForm = ({
       e.preventDefault();
     }
   };
+
+  const sortedRadios = sortRadioTypes(Object.keys(radioTypes || []));
 
   const radioOptions = (
     <Radio.Group>
@@ -242,7 +245,7 @@ const SSIDForm = ({
 
         <Item name="appliedRadios" label="Use On">
           <CheckboxGroup>
-            {Object.keys(radioTypes || [])?.map(i => (
+            {sortedRadios.map(i => (
               <Checkbox key={i} value={i}>
                 {radioTypes?.[i]}
               </Checkbox>
@@ -799,7 +802,7 @@ const SSIDForm = ({
       <Card title="Roaming">
         <Item label="Advanced Settings" colon={false}>
           <div className={styles.InlineDiv}>
-            {Object.keys(radioTypes || [])?.map(i => (
+            {sortedRadios.map(i => (
               <span key={i}>{radioTypes?.[i]}</span>
             ))}
           </div>

--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -6,7 +6,6 @@ import Tooltip from 'components/Tooltip';
 import ThemeContext from 'contexts/ThemeContext';
 
 import globalStyles from 'styles/index.scss';
-import { sortRadioTypes } from 'utils/sortRadioTypes';
 import styles from '../index.module.scss';
 import { defaultSsidProfile } from '../constants';
 import { RADIOS, ROAMING, PROFILES, IP_REGEX } from '../../constants/index';
@@ -36,8 +35,6 @@ const SSIDForm = ({
       e.preventDefault();
     }
   };
-
-  const sortedRadios = sortRadioTypes(Object.keys(radioTypes || []));
 
   const radioOptions = (
     <Radio.Group>
@@ -245,7 +242,7 @@ const SSIDForm = ({
 
         <Item name="appliedRadios" label="Use On">
           <CheckboxGroup>
-            {sortedRadios.map(i => (
+            {Object.keys(radioTypes || {})?.map(i => (
               <Checkbox key={i} value={i}>
                 {radioTypes?.[i]}
               </Checkbox>
@@ -802,7 +799,7 @@ const SSIDForm = ({
       <Card title="Roaming">
         <Item label="Advanced Settings" colon={false}>
           <div className={styles.InlineDiv}>
-            {sortedRadios.map(i => (
+            {Object.keys(radioTypes || {})?.map(i => (
               <span key={i}>{radioTypes?.[i]}</span>
             ))}
           </div>

--- a/src/containers/ProfileDetails/constants/index.js
+++ b/src/containers/ProfileDetails/constants/index.js
@@ -1,4 +1,4 @@
-export const RADIOS = ['is2dot4GHz', 'is5GHz', 'is5GHzU', 'is5GHzL'];
+export const RADIOS = ['is2dot4GHz', 'is5GHz', 'is5GHzL', 'is5GHzU'];
 export const ROAMING = ['enable80211r', 'enable80211k', 'enable80211v'];
 export const DEFAULT_NTP_SERVER = 'pool.ntp.org';
 export const DEFAULT_HESS_ID = '00:00:00:00:00:00';

--- a/src/utils/sortRadioTypes.js
+++ b/src/utils/sortRadioTypes.js
@@ -1,5 +1,5 @@
 export const sortRadioTypes = obj => {
-  const sortOrder = ['is2dot4GHz', 'is5GHz', 'is5GHzU', 'is5GHzL'];
+  const sortOrder = ['is2dot4GHz', 'is5GHz', 'is5GHzL', 'is5GHzU'];
 
   return obj.sort((a, b) => sortOrder.indexOf(a) - sortOrder.indexOf(b));
 };


### PR DESCRIPTION
NO-JIRA

## Description
*Summary of this PR*

Changed Sort Order on SSID page from "2.4GHz,  5GHz (L), 5GHz (U), 5GHz" to "2.4GHz, 5GHz, 5GHz L, 5GHz U"

Changed 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/123460386-8c9f9e80-d5b5-11eb-9eff-21d3d3204eb6.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/123460325-7691de00-d5b5-11eb-9ce6-ecf2b9e0a007.png)
