### PR TITLE
bugfix/WIFI:2854: Made RF/SSID profiles selections required on AP profile

### DIFF
--- a/src/containers/AddProfile/index.js
+++ b/src/containers/AddProfile/index.js
@@ -123,10 +123,18 @@ const AddProfile = ({
         }
 
         if (profileType === PROFILES.accessPoint) {
-          if (!values.rfProfileId) {
+          if (!values.rfProfileId?.value) {
             notification.error({
               message: 'Error',
               description: 'A Rf Profile is required.',
+            });
+            return;
+          }
+
+          if (!values.selectedSsidProfiles?.length) {
+            notification.error({
+              message: 'Error',
+              description: 'A SSID Profile is required.',
             });
             return;
           }

--- a/src/containers/ProfileDetails/index.js
+++ b/src/containers/ProfileDetails/index.js
@@ -121,10 +121,18 @@ const ProfileDetails = ({
           formattedData = Object.assign(formattedData, formatSsidProfileForm(values));
         }
         if (profileType === PROFILES.accessPoint) {
-          if (!values.rfProfileId) {
+          if (!values.rfProfileId?.value) {
             notification.error({
               message: 'Error',
               description: 'A Rf Profile is required.',
+            });
+            return;
+          }
+
+          if (!values.selectedSsidProfiles?.length) {
+            notification.error({
+              message: 'Error',
+              description: 'A SSID Profile is required.',
             });
             return;
           }


### PR DESCRIPTION
JIRA: [WIFI-2854](https://telecominfraproject.atlassian.net/browse/WIFI-2854)

## Description
*Summary of this PR*

Made RF/SSID profiles selections required on AP profile. Previously, an AP profile could be created and updated without them.

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*