### PR TITLE
bugfix/WIFI-2826: Use Latest Metric for stats

### DIFF
--- a/src/containers/ClientDeviceDetails/index.js
+++ b/src/containers/ClientDeviceDetails/index.js
@@ -35,7 +35,6 @@ const ClientDeviceDetails = ({
     hostname,
     ssid,
     radioType,
-    signal,
     manufacturer,
     equipment,
     details,
@@ -61,6 +60,7 @@ const ClientDeviceDetails = ({
   } = latestMetrics?.detailsJSON || {};
   const rxThroughput = rxBytes / periodLengthSec;
   const txThroughput = txBytes / periodLengthSec;
+  const signal = `${rssi}`;
 
   const status = useMemo(() => {
     if (details?.associationState === 'Active_Data') {
@@ -78,7 +78,7 @@ const ClientDeviceDetails = ({
     'Access Point': equipment?.name,
     SSID: ssid,
     'Radio Band': radioTypes?.[radioType],
-    'Signal Strength': `${rssi} dBm`,
+    'Signal Strength': `${signal} dBm`,
     'Tx Rate': `${formatBitsPerSecond(averageTxRate * 1000)}`,
     'Rx Rate': `${formatBitsPerSecond(averageRxRate * 1000)}`,
   });
@@ -121,7 +121,7 @@ const ClientDeviceDetails = ({
         macAddress={macAddress}
         ipAddress={ipAddress}
         radioType={radioType}
-        signal={rssi.toString()}
+        signal={signal}
         dataTransferred={txBytes + rxBytes}
         dataThroughput={txThroughput + rxThroughput}
         status={status}


### PR DESCRIPTION
JIRA: [WIFI-2826](https://telecominfraproject.atlassian.net/browse/WIFI-2826)

## Description
Mon Jun 28

Use the latest metric to show the Client Device stats instead of metricDetails which has been deprecated.
- Throughput => bytes/periodLengthSec
- packets => frames
- kbps => averageRate

### Before this PR
![Screen Shot 2021-06-28 at 4 57 34 PM](https://user-images.githubusercontent.com/69811026/123707888-735a5480-d838-11eb-9c39-98c8fc8682e1.png)


### After this PR
<img width="1069" alt="Screen Shot 2021-06-28 at 4 57 40 PM" src="https://user-images.githubusercontent.com/69811026/123707899-76eddb80-d838-11eb-9bb4-b73238b3fa7f.png">
