### PR TITLE
bugfix/WIFI-2962: Added channel bandwidth to AP details page

### DIFF
--- a/src/components/DisabledText/index.js
+++ b/src/components/DisabledText/index.js
@@ -4,12 +4,12 @@ import PropTypes from 'prop-types';
 import Tooltip from 'components/Tooltip';
 import styles from './index.module.scss';
 
-const DisabledText = ({ value, title, text }) => (
+const DisabledText = ({ value, title, text, showTooltip }) => (
   <Input
     className={styles.Input}
     value={value}
     disabled
-    addonAfter={<Tooltip title={title} text={text} />}
+    addonAfter={showTooltip ? <Tooltip title={title} text={text} /> : null}
   />
 );
 
@@ -19,10 +19,12 @@ DisabledText.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   title: PropTypes.string,
   text: PropTypes.string,
+  showTooltip: PropTypes.bool,
 };
 
 DisabledText.defaultProps = {
   value: 'N/A',
   title: null,
   text: null,
+  showTooltip: true,
 };

--- a/src/containers/AccessPointDetails/components/General/constants.js
+++ b/src/containers/AccessPointDetails/components/General/constants.js
@@ -20,6 +20,13 @@ export const ALLOWED_CHANNELS_STEP = {
   is160MHz: 8,
 };
 
+export const USER_FRIENDLY_BANDWIDTHS = {
+  is20MHz: '20MHz',
+  is40MHz: '40MHz',
+  is80MHz: '80MHz',
+  is160MHz: '160MHz',
+};
+
 export const MAX_CHANNEL_WIDTH_40MHZ_OR_80MHZ = 157;
 
 export const MAX_CHANNEL_WIDTH_160MHZ = 100;

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useContext, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import {
   Card,
@@ -20,6 +21,7 @@ import { sortRadioTypes } from 'utils/sortRadioTypes';
 import { pageLayout } from 'utils/form';
 import {
   USER_FRIENDLY_RATES,
+  USER_FRIENDLY_BANDWIDTHS,
   ALLOWED_CHANNELS_STEP,
   MAX_CHANNEL_WIDTH_40MHZ_OR_80MHZ,
   MAX_CHANNEL_WIDTH_160MHZ,
@@ -44,13 +46,15 @@ const General = ({
   extraFields,
   extraGeneralCards,
 }) => {
-  const { radioTypes } = useContext(ThemeContext);
+  const { radioTypes, routes } = useContext(ThemeContext);
+
   const [form] = Form.useForm();
   const columns = [
     {
       title: 'Wireless Network',
-      dataIndex: 'name',
-      key: 'network',
+      render: (__, record) => (
+        <Link to={`${routes.profiles}/${record.id}`}>{record.name ?? 'N/A'} </Link>
+      ),
     },
     {
       title: 'SSID',
@@ -456,6 +460,24 @@ const General = ({
     );
   };
 
+  const renderBandwidthLabels = () => (
+    <Item label="Channel Bandwidth">
+      <div className={styles.InlineDiv}>
+        {sortRadioTypes(Object.keys(data.details.radioMap)).map(radio => (
+          <DisabledText
+            key={radio}
+            value={
+              USER_FRIENDLY_BANDWIDTHS[
+                childProfiles.rf?.[0]?.details?.rfConfigMap?.[radio].channelBandwidth
+              ] ?? 'N/A'
+            }
+            showTooltip={false}
+          />
+        ))}
+      </div>
+    </Item>
+  );
+
   if (errorProfiles) {
     return (
       <Alert
@@ -536,7 +558,11 @@ const General = ({
           </Select>
         </Item>
 
-        <Item label="RF Profile">{childProfiles.rf?.[0]?.name || 'N/A'}</Item>
+        <Item label="RF Profile">
+          <Link to={`${routes.profiles}/${childProfiles.rf?.[0]?.id}`}>
+            {childProfiles.rf?.[0]?.name || 'N/A'}
+          </Link>
+        </Item>
         <Item label="Summary">
           <Item>
             <Table
@@ -555,6 +581,7 @@ const General = ({
         <Panel header="Advanced Settings" name="settings">
           {renderItem(' ', data.details.radioMap, 'radioType')}
           <p>Radio Specific Parameters:</p>
+          {renderBandwidthLabels()}
           {renderItem('Enable Radio', advancedRadioMap, ['radioAdminState'], renderOptionItem, {
             dropdown: defaultOptions,
             mapName: 'advancedRadioMap',

--- a/src/containers/AccessPointDetails/components/General/tests/index.test.js
+++ b/src/containers/AccessPointDetails/components/General/tests/index.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
+import { MemoryRouter } from 'react-router-dom';
 import { fireEvent, waitForElement, waitFor } from '@testing-library/react';
 import { render, DOWN_ARROW } from 'tests/utils';
 import { defaultProps } from '../../../tests/constants';
@@ -19,9 +20,16 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
+const renderWithMemory = extraProps =>
+  render(
+    <MemoryRouter>
+      <General {...defaultProps} {...extraProps} />
+    </MemoryRouter>
+  );
+
 describe('<General />', () => {
   it('changing the access point profile should update table', async () => {
-    const { getByText, getByLabelText, getAllByText } = render(<General {...defaultProps} />);
+    const { getByText, getByLabelText, getAllByText } = renderWithMemory();
 
     const apProfile = getByLabelText('Access Point Profile');
 
@@ -37,7 +45,7 @@ describe('<General />', () => {
   });
 
   it('handleSubmit should not be called if access point name is empty on general tab', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.change(getByPlaceholderText('Enter Access Point Name'), {
       target: { value: null },
@@ -51,9 +59,9 @@ describe('<General />', () => {
 
   it('handleSubmit should be called if access point name is entered on general tab', async () => {
     const submitSpy = jest.fn();
-    const { getByText, getByRole, getByPlaceholderText } = render(
-      <General {...defaultProps} handleOnEquipmentSave={submitSpy} />
-    );
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory({
+      handleOnEquipmentSave: submitSpy,
+    });
 
     const paragraph = getByText('Identity');
     expect(paragraph).toBeVisible();
@@ -69,7 +77,7 @@ describe('<General />', () => {
   });
 
   it('advanced setting tab should load on clicking the dropdown ', async () => {
-    const { getByText, getByRole } = render(<General {...defaultProps} />);
+    const { getByText, getByRole } = renderWithMemory();
 
     const paragraph = getByText('Identity');
     expect(paragraph).toBeVisible();
@@ -78,7 +86,7 @@ describe('<General />', () => {
 
   it('handleSubmit should be called if advanced settings are filled', async () => {
     const submitSpy = jest.fn();
-    const { getByRole } = render(<General {...defaultProps} handleOnEquipmentSave={submitSpy} />);
+    const { getByRole } = renderWithMemory({ handleOnEquipmentSave: submitSpy });
 
     fireEvent.click(getByRole('button', { name: 'Save' }));
 
@@ -97,7 +105,7 @@ describe('<General />', () => {
 
   // Probe response threshold
   it('error if the probe response threshold exceeds bounds for the 2.4GHz setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -111,7 +119,7 @@ describe('<General />', () => {
     });
   });
   it('error if the probe response threshold exceeds bounds for the 5GHz (U) setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -125,7 +133,7 @@ describe('<General />', () => {
     });
   });
   it('error if the probe response threshold exceeds bounds for the 5GHz (L) setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -141,7 +149,7 @@ describe('<General />', () => {
 
   // Client disconnect threshold
   it('error if the client disconnect threshold exceeds bounds for the 2.4GHz setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -155,7 +163,7 @@ describe('<General />', () => {
     });
   });
   it('error if the client disconnect threshold exceeds bounds for the 5GHz (U) setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -169,7 +177,7 @@ describe('<General />', () => {
     });
   });
   it('error if the client disconnect threshold exceeds bounds for the 5GHz (L) setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -185,7 +193,7 @@ describe('<General />', () => {
 
   // Eirp TX power
   it('error if the eirp tx power exceeds bounds for the 2.4GHz setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -199,7 +207,7 @@ describe('<General />', () => {
     });
   });
   it('error if the eirp tx power exceeds bounds for the 5GHz (U) setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -213,7 +221,7 @@ describe('<General />', () => {
     });
   });
   it('error if the eirp tx power exceeds bounds for the 5GHz (L) setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -229,7 +237,7 @@ describe('<General />', () => {
 
   // Min load
   it('error if the minimum load percentage exceeds bounds for the 2.4GHz setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -243,7 +251,7 @@ describe('<General />', () => {
     });
   });
   it('error if the minimum load percentage exceeds bounds for the 5GHz (U) setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -257,7 +265,7 @@ describe('<General />', () => {
     });
   });
   it('error if the minimum load percentage exceeds bounds for the 5GHz (L) setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -273,7 +281,7 @@ describe('<General />', () => {
 
   // Snr
   it('error if the snr percentage drop exceeds bounds for the 2.4GHz setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -287,7 +295,7 @@ describe('<General />', () => {
     });
   });
   it('error if the snr percentage drop exceeds bounds for the 5GHz (U) setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -302,7 +310,7 @@ describe('<General />', () => {
   });
 
   it('error if the snr percentage drop exceeds bounds for the 5GHz (L) setting', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -317,7 +325,7 @@ describe('<General />', () => {
   });
 
   it('Active channel field should be disabled if autoChannelSelection setting is enabled', async () => {
-    const { getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -326,7 +334,7 @@ describe('<General />', () => {
   });
 
   it('Backup channel field should be disabled if autoChannelSelection setting is enabled', async () => {
-    const { getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -335,7 +343,7 @@ describe('<General />', () => {
   });
 
   it('error if active channel input exceends bounds', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -349,7 +357,7 @@ describe('<General />', () => {
   });
 
   it('error if backup channel input exceends bounds', async () => {
-    const { getByText, getByRole, getByPlaceholderText } = render(<General {...defaultProps} />);
+    const { getByText, getByRole, getByPlaceholderText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 
@@ -363,9 +371,7 @@ describe('<General />', () => {
   });
 
   it('error if active and backup channel inputs are the same', async () => {
-    const { getByText, getByRole, getByPlaceholderText, queryByText } = render(
-      <General {...defaultProps} />
-    );
+    const { getByText, getByRole, getByPlaceholderText, queryByText } = renderWithMemory();
 
     fireEvent.click(getByRole('button', { name: /settings/i }));
 

--- a/src/containers/AccessPointDetails/components/Status/index.js
+++ b/src/containers/AccessPointDetails/components/Status/index.js
@@ -4,6 +4,7 @@ import { CheckCircleOutlined, InfoCircleOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types';
 import ThemeContext from 'contexts/ThemeContext';
 import { sortRadioTypes } from 'utils/sortRadioTypes';
+import { USER_FRIENDLY_BANDWIDTHS } from '../General/constants';
 
 import styles from '../../index.module.scss';
 
@@ -78,6 +79,24 @@ const Status = ({ data, showAlarms, extraFields }) => {
     </Item>
   );
 
+  const renderBandwidthLabels = () => {
+    const rfProfile = data?.profile?.childProfiles?.find(
+      profile => profile?.details?.profileType === 'rf'
+    );
+    return (
+      <Item label="Channel Bandwidth">
+        <div className={styles.InlineDiv}>
+          {sortRadioTypes(Object.keys(data.details.radioMap)).map(i => (
+            <span key={i} className={styles.spanStyle}>
+              {USER_FRIENDLY_BANDWIDTHS[rfProfile?.details?.rfConfigMap?.[i].channelBandwidth] ??
+                'N/A'}
+            </span>
+          ))}
+        </div>
+      </Item>
+    );
+  };
+
   return (
     <>
       <Form {...layout}>
@@ -112,6 +131,7 @@ const Status = ({ data, showAlarms, extraFields }) => {
         </Card>
         <Card title="Radio">
           {renderSpanItem({ label: ' ', obj: radioMap, dataIndex: 'radioType' })}
+          {renderBandwidthLabels()}
           {renderSpanItem({
             label: 'Channel',
             obj: status?.channel?.detailsJSON?.channelNumberStatusDataMap,

--- a/src/containers/AccessPointDetails/index.module.scss
+++ b/src/containers/AccessPointDetails/index.module.scss
@@ -38,7 +38,7 @@
   .InlineBlockDiv {
     display: inline-block;
     vertical-align: middle;
-    :global(.ant-avatar ){
+    :global(.ant-avatar) {
       margin-right: 20px;
     }
   }
@@ -110,5 +110,9 @@
 
   .tabContentContainer {
     margin-top: 10px;
+  }
+
+  a {
+    color: white;
   }
 }


### PR DESCRIPTION
JIRA: [WIFI-2962](https://telecominfraproject.atlassian.net/browse/WIFI-2962)

## Description
*Summary of this PR*
Quality of Life improvements to AP Details Page: 
- General and Status tab now show channel bandwidth from associated RF-Profile
- Clicking on the name of the RF-Profile or SSID profile on the General page will route user to the specific profile 

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/124810088-e6498680-df2e-11eb-8a0c-908efdb2f8eb.png)
![image](https://user-images.githubusercontent.com/55258316/124810057-dd58b500-df2e-11eb-94b2-43ed170e24a2.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/124809936-b26e6100-df2e-11eb-85bc-3c6b7200176d.png)
![image](https://user-images.githubusercontent.com/55258316/124809959-ba2e0580-df2e-11eb-8107-598c6463787e.png)
