### PR TITLE
hotfix/SsidRadiusAcctInterval: Fixed RADIUS Accounting Interval input field

### DIFF
--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -691,7 +691,7 @@ const SSIDForm = ({
               className={globalStyles.field}
               placeholder="0 or 60 - 600 "
               type="number"
-              min={60}
+              min={0}
               max={600}
               addonAfter={
                 <Tooltip title="Interval can be 0 or a number between 60 and 600" text="Seconds" />


### PR DESCRIPTION
NO-JIRA

## Description
*Summary of this PR*

- Changed `min` value on RADIUS Accounting Interval input field from "60" to "0" to fix bug that prevented user from saving profile when value was 0 

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*