### PR TITLE
bugfix/WIFI-2419: Disabled Save Button on Untouched AP Details page

### DIFF
--- a/src/components/Button/index.module.scss
+++ b/src/components/Button/index.module.scss
@@ -1,7 +1,6 @@
 .Button {
   margin-right: 25px;
-}
-
-.Button:last-child {
-  margin-right: 0px;
+  &:last-child {
+    margin-right: 0px;
+  }
 }

--- a/src/containers/AccessPointDetails/components/Firmware/index.js
+++ b/src/containers/AccessPointDetails/components/Firmware/index.js
@@ -74,13 +74,13 @@ const Firmware = ({
 
   const renderModalContent = () => {
     if (confirmModal === MODAL_REBOOT) {
-      return 'Confirm Reboot AP?';
+      return 'Confirm reboot access point?';
     }
     if (confirmModal === MODAL_INACTIVE) {
-      return 'Confirm Switch to Inactive Bank and Reboot?';
+      return 'Confirm switch to inactive bank and reboot?';
     }
     if (confirmModal === MODAL_DOWNLOAD) {
-      return 'Confirm downloading, flashing, rebooting?';
+      return 'Confirm downloading, flashing, and rebooting?';
     }
     return null;
   };
@@ -137,7 +137,7 @@ const Firmware = ({
         onCancel={() => setConfirmModal(false)}
         onSuccess={handleOnSuccessModal}
         visible={Boolean(confirmModal)}
-        title="Confirm"
+        title="Confirm?"
         content={renderModalContent()}
         buttonText="Confirm"
       />
@@ -150,7 +150,7 @@ const Firmware = ({
               name="reboot"
               disabled={getRebootStatus()}
             >
-              Reboot AP
+              Reboot Access Point
             </Button>
           </div>
         </WithRoles>

--- a/src/containers/AccessPointDetails/components/Firmware/tests/index.test.js
+++ b/src/containers/AccessPointDetails/components/Firmware/tests/index.test.js
@@ -104,8 +104,9 @@ describe('<Firmware />', () => {
     await waitForElement(() => getByText(firmware[0].versionName));
     fireEvent.click(getByText(firmware[0].versionName));
 
-    fireEvent.click(getByRole('button', { name: /download Download, Flash, and Reboot/i }));
-    expect(getByText('Confirm downloading, flashing, rebooting?')).toBeVisible();
+    fireEvent.click(getByRole('button', { name: /download, flash, and reboot?/i }));
+
+    expect(getByText('Confirm downloading, flashing, and rebooting?')).toBeVisible();
 
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
@@ -136,9 +137,9 @@ describe('<Firmware />', () => {
     await waitForElement(() => getByText(firmware[0].versionName));
     fireEvent.click(getByText(firmware[0].versionName));
 
-    fireEvent.click(getByRole('button', { name: /download Download, Flash, and Reboot/i }));
+    fireEvent.click(getByRole('button', { name: /download, flash, and reboot/i }));
 
-    expect(getByText('Confirm downloading, flashing, rebooting?')).toBeVisible();
+    expect(getByText('Confirm downloading, flashing, and rebooting?')).toBeVisible();
 
     fireEvent.click(getByRole('button', { name: 'Confirm' }));
 
@@ -165,9 +166,9 @@ describe('<Firmware />', () => {
     await waitForElement(() => getByText(firmware[0].versionName));
     fireEvent.click(getByText(firmware[0].versionName));
 
-    fireEvent.click(getByRole('button', { name: /download Download, Flash, and Reboot/i }));
+    fireEvent.click(getByRole('button', { name: /download, flash, and reboot/i }));
 
-    expect(getByText('Confirm downloading, flashing, rebooting?')).toBeVisible();
+    expect(getByText('Confirm downloading, flashing, and rebooting?')).toBeVisible();
 
     fireEvent.click(getByRole('button', { name: 'Confirm' }));
   });

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -45,6 +45,7 @@ const General = ({
   onSearchProfile,
   extraFields,
   extraGeneralCards,
+  isFormDirty,
 }) => {
   const { radioTypes, routes } = useContext(ThemeContext);
   const history = useHistory();
@@ -468,12 +469,12 @@ const General = ({
   const renderBandwidthLabels = () => (
     <Item label="Channel Bandwidth">
       <div className={styles.InlineDiv}>
-        {sortRadioTypes(Object.keys(data.details.radioMap)).map(radio => (
+        {sortRadioTypes(Object.keys(data?.details?.radioMap ?? {})).map(radio => (
           <DisabledText
             key={radio}
             value={
               USER_FRIENDLY_BANDWIDTHS[
-                childProfiles.rf?.[0]?.details?.rfConfigMap?.[radio].channelBandwidth
+                childProfiles?.rf?.[0]?.details?.rfConfigMap?.[radio].channelBandwidth
               ] ?? 'N/A'
             }
             showTooltip={false}
@@ -503,6 +504,7 @@ const General = ({
           onClick={handleOnSave}
           type="primary"
           name="save"
+          disabled={!isFormDirty}
         >
           Save
         </RoleProtectedBtn>
@@ -750,6 +752,7 @@ General.propTypes = {
   onSearchProfile: PropTypes.func,
   extraFields: PropTypes.instanceOf(Array),
   extraGeneralCards: PropTypes.node,
+  isFormDirty: PropTypes.bool,
 };
 
 General.defaultProps = {
@@ -763,6 +766,7 @@ General.defaultProps = {
   onSearchProfile: null,
   extraFields: [],
   extraGeneralCards: null,
+  isFormDirty: false,
 };
 
 export default General;

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -469,7 +469,7 @@ const General = ({
   const renderBandwidthLabels = () => (
     <Item label="Channel Bandwidth">
       <div className={styles.InlineDiv}>
-        {sortRadioTypes(Object.keys(data?.details?.radioMap ?? {})).map(radio => (
+        {sortRadioTypes(Object.keys(radioMap)).map(radio => (
           <DisabledText
             key={radio}
             value={

--- a/src/containers/AccessPointDetails/components/Location/index.js
+++ b/src/containers/AccessPointDetails/components/Location/index.js
@@ -9,7 +9,7 @@ import styles from '../../index.module.scss';
 const { Item } = Form;
 const { Option } = AntdSelect;
 
-const Location = ({ locations, data, handleOnEquipmentSave, handleOnFormChange }) => {
+const Location = ({ locations, data, handleOnEquipmentSave, handleOnFormChange, isFormDirty }) => {
   const [form] = Form.useForm();
 
   const getLocationPath = () => {
@@ -116,7 +116,12 @@ const Location = ({ locations, data, handleOnEquipmentSave, handleOnFormChange }
     <Form {...pageLayout} form={form} onValuesChange={handleOnFormChange}>
       <WithRoles>
         <div className={styles.InlineEndDiv}>
-          <Button className={styles.saveButton} onClick={handleOnSave} type="primary">
+          <Button
+            className={styles.saveButton}
+            onClick={handleOnSave}
+            type="primary"
+            disabled={!isFormDirty}
+          >
             Save
           </Button>
         </div>
@@ -164,12 +169,14 @@ Location.propTypes = {
   locations: PropTypes.instanceOf(Array).isRequired,
   handleOnEquipmentSave: PropTypes.func,
   handleOnFormChange: PropTypes.func,
+  isFormDirty: PropTypes.bool,
 };
 
 Location.defaultProps = {
   data: {},
   handleOnFormChange: () => {},
   handleOnEquipmentSave: () => {},
+  isFormDirty: false,
 };
 
 export default Location;

--- a/src/containers/AccessPointDetails/components/Status/index.js
+++ b/src/containers/AccessPointDetails/components/Status/index.js
@@ -86,7 +86,7 @@ const Status = ({ data, showAlarms, extraFields }) => {
     return (
       <Item label="Channel Bandwidth">
         <div className={styles.InlineDiv}>
-          {sortRadioTypes(Object.keys(data.details.radioMap)).map(i => (
+          {sortRadioTypes(Object.keys(radioMap)).map(i => (
             <span key={i} className={styles.spanStyle}>
               {USER_FRIENDLY_BANDWIDTHS[rfProfile?.details?.rfConfigMap?.[i].channelBandwidth] ??
                 'N/A'}

--- a/src/containers/AccessPointDetails/index.js
+++ b/src/containers/AccessPointDetails/index.js
@@ -142,9 +142,13 @@ const AccessPointDetails = ({
           }
         }}
         visible={confirmModal}
-        buttonText="OK"
+        buttonText="Leave Page"
         title="Leave Page?"
-        content={<p>Please confirm exiting without saving this Access Point page.</p>}
+        content={
+          <p>
+            You have unsaved changes. Please confirm leaving without saving this access point page:
+          </p>
+        }
         mask={false}
       />
       <Header>
@@ -217,6 +221,7 @@ const AccessPointDetails = ({
           onSearchProfile={onSearchProfile}
           extraFields={extraGeneralFields}
           extraGeneralCards={extraGeneralCards}
+          isFormDirty={isFormDirty}
         />
       )}
       {tab === 'status' && (
@@ -228,9 +233,12 @@ const AccessPointDetails = ({
           locations={locations}
           handleOnEquipmentSave={handleOnEquipmentSave}
           handleOnFormChange={handleOnFormChange}
+          isFormDirty={isFormDirty}
         />
       )}
-      {tab === 'os' && <OS data={data} osData={osData} handleRefresh={handleRefresh} />}
+      {tab === 'os' && (
+        <OS data={data} osData={osData} handleRefresh={handleRefresh} isFormDirty={isFormDirty} />
+      )}
       {tab === 'firmware' && (
         <Firmware
           firmware={firmware}
@@ -241,6 +249,7 @@ const AccessPointDetails = ({
           onRequestEquipmentReboot={onRequestEquipmentReboot}
           loadingFirmware={loadingFirmware}
           errorFirmware={errorFirmware}
+          isFormDirty={isFormDirty}
         />
       )}
       {extraTabs.map(

--- a/src/containers/AccessPointDetails/index.module.scss
+++ b/src/containers/AccessPointDetails/index.module.scss
@@ -73,11 +73,9 @@
   }
 
   .saveButton {
-    border: 1px solid #434343;
-    border-radius: 5px;
     margin-top: 10px;
-    margin-bottom: 0;
-    width: 139px;
+    min-width: 139px;
+    max-width: 100%;
   }
 
   .InlineEndDiv {

--- a/src/containers/AccessPointDetails/tests/constants.js
+++ b/src/containers/AccessPointDetails/tests/constants.js
@@ -597,4 +597,5 @@ export const defaultProps = {
       dependencies: 'autoCellSizeSelection',
     },
   ],
+  isFormDirty: true,
 };

--- a/src/containers/AccessPointDetails/tests/index.test.js
+++ b/src/containers/AccessPointDetails/tests/index.test.js
@@ -37,6 +37,46 @@ describe('<AccessPointDetails />', () => {
     expect(paragraph).toBeVisible();
   });
 
+  it('general tab save button should be disabled by default', async () => {
+    const { getByRole, getByText } = render(
+      <MemoryRouter initialEntries={['/network/access-points/1/general']}>
+        <Route path="/network/access-points/:id/:tab">
+          <AccessPointDetails {...defaultProps} />
+        </Route>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(getByRole('tab', { name: /general/i }));
+    const paragraph = getByText('Identity');
+    expect(paragraph).toBeVisible();
+
+    const button = getByRole('button', { name: /save/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('general tab save button should no longer be disabled after form is changed', async () => {
+    const { getByRole, getByText, getByPlaceholderText } = render(
+      <MemoryRouter initialEntries={['/network/access-points/1/general']}>
+        <Route path="/network/access-points/:id/:tab">
+          <AccessPointDetails {...defaultProps} />
+        </Route>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(getByRole('tab', { name: /general/i }));
+    const paragraph = getByText('Identity');
+    expect(paragraph).toBeVisible();
+
+    const button = getByRole('button', { name: /save/i });
+    expect(button).toBeDisabled();
+
+    fireEvent.change(getByPlaceholderText('Enter Access Point Name'), {
+      target: { value: 'testName' },
+    });
+
+    expect(button).not.toBeDisabled();
+  });
+
   it('status tab should show the status form', async () => {
     const data = { ...defaultProps, data: { ...defaultProps.data, alarmsCount: 1 } };
     const { getByRole, getByText } = render(
@@ -82,6 +122,52 @@ describe('<AccessPointDetails />', () => {
     expect(paragraph).toBeVisible();
   });
 
+  it('location tab save button should be disabled by default', async () => {
+    const { getByRole, getByText } = render(
+      <MemoryRouter initialEntries={['/network/access-points/1/general']}>
+        <Route path="/network/access-points/:id/:tab">
+          <AccessPointDetails {...defaultProps} />
+        </Route>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(getByRole('tab', { name: /location/i }));
+    const paragraph = getByText('Level 0');
+    expect(paragraph).toBeVisible();
+
+    const button = getByRole('button', { name: /save/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('location tab save button should no longer be disabled if form is changed', async () => {
+    const { getByRole, getByText, getByLabelText } = render(
+      <MemoryRouter initialEntries={['/network/access-points/1/general']}>
+        <Route path="/network/access-points/:id/:tab">
+          <AccessPointDetails {...defaultProps} />
+        </Route>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(getByRole('tab', { name: /location/i }));
+    const paragraph = getByText('Level 0');
+    expect(paragraph).toBeVisible();
+
+    const button = getByRole('button', { name: /save/i });
+    expect(button).toBeDisabled();
+
+    const country = getByLabelText('Level 0');
+    fireEvent.keyDown(country, DOWN_ARROW);
+    await waitForElement(() => getByText('Menlo Park'));
+    fireEvent.click(getByText('Menlo Park'));
+
+    const site1 = getByLabelText('Level 1');
+    fireEvent.keyDown(site1, DOWN_ARROW);
+    await waitForElement(() => getByText('Building 1'));
+    fireEvent.click(getByText('Building 1'));
+
+    expect(button).not.toBeDisabled();
+  });
+
   it('firmware tab should show the firmware form', async () => {
     const { getByRole, getByText } = render(
       <MemoryRouter initialEntries={['/network/access-points/1/general']}>
@@ -114,9 +200,7 @@ describe('<AccessPointDetails />', () => {
       target: { value: 'test' },
     });
     fireEvent.click(getByRole('tab', { name: /status/i }));
-    expect(
-      getByText('Please confirm exiting without saving this Access Point page.')
-    ).toBeVisible();
+    expect(getByText(/Please confirm leaving without saving this access point page/)).toBeVisible();
     fireEvent.click(getByRole('button', { name: /cancel/i }));
 
     expect(paragraph).toBeVisible();
@@ -142,16 +226,14 @@ describe('<AccessPointDetails />', () => {
       target: { value: 'test' },
     });
     fireEvent.click(getByRole('tab', { name: /status/i }));
-    expect(
-      getByText('Please confirm exiting without saving this Access Point page.')
-    ).toBeVisible();
-    fireEvent.click(getByRole('button', { name: /ok/i }));
+    expect(getByText(/Please confirm leaving without saving this access point page/)).toBeVisible();
+    fireEvent.click(getByRole('button', { name: /leave page/i }));
 
     const statusParagraph = getByText('Noise Floor');
     expect(statusParagraph).toBeVisible();
   });
 
-  it('Confirm leave form Modal should appear if General tab form is changed', () => {
+  it('Confirm leave page Modal should appear if General tab form is changed', () => {
     const { getByRole, getByPlaceholderText, getByText } = render(
       <MemoryRouter initialEntries={['/network/access-points/1/general']}>
         <Route path="/network/access-points/:id/:tab">
@@ -166,12 +248,10 @@ describe('<AccessPointDetails />', () => {
       target: { value: 'test' },
     });
     fireEvent.click(getByRole('button', { name: /back/i }));
-    expect(
-      getByText('Please confirm exiting without saving this Access Point page.')
-    ).toBeVisible();
+    expect(getByText(/Please confirm leaving without saving this access point page/)).toBeVisible();
   });
 
-  it('Confirm leave form Modal should appear if Location tab form is changed', async () => {
+  it('Confirm leave page Modal should appear if Location tab form is changed', async () => {
     const { getByRole, getByLabelText, getByText } = render(
       <MemoryRouter initialEntries={['/network/access-points/1/general']}>
         <Route path="/network/access-points/:id/:tab">
@@ -188,14 +268,12 @@ describe('<AccessPointDetails />', () => {
     fireEvent.click(getByText(defaultProps.locations[0].children[0].name));
 
     fireEvent.click(getByRole('button', { name: /back/i }));
-    expect(
-      getByText('Please confirm exiting without saving this Access Point page.')
-    ).toBeVisible();
+    expect(getByText(/Please confirm leaving without saving this access point page/)).toBeVisible();
 
     fireEvent.click(getByRole('button', { name: /cancel/i }));
   });
 
-  it('Confirm leave form Modal should appear if Firmware tab form is changed', async () => {
+  it('Confirm leave page Modal should appear if Firmware tab form is changed', async () => {
     const { getByRole, getByText } = render(
       <MemoryRouter initialEntries={['/network/access-points/1/general']}>
         <Route path="/network/access-points/:id/:tab">
@@ -215,9 +293,7 @@ describe('<AccessPointDetails />', () => {
     fireEvent.click(getByText(firmware[2].versionName));
 
     fireEvent.click(getByRole('button', { name: /back/i }));
-    expect(
-      getByText('Please confirm exiting without saving this Access Point page.')
-    ).toBeVisible();
+    expect(getByText(/Please confirm leaving without saving this access point page/)).toBeVisible();
 
     fireEvent.click(getByRole('button', { name: /cancel/i }));
 
@@ -226,7 +302,7 @@ describe('<AccessPointDetails />', () => {
     fireEvent.click(getByText(firmware[3].versionName));
   });
 
-  it('Confirm leave form Modal should not be visible if form is saved and User clicks back', async () => {
+  it('Confirm leave page Modal should not be visible if form is saved and User clicks back', async () => {
     const { getByRole, getByLabelText, getByText } = render(
       <MemoryRouter initialEntries={['/network/access-points/1/general']}>
         <Route path="/network/access-points/:id/:tab">
@@ -243,14 +319,14 @@ describe('<AccessPointDetails />', () => {
     fireEvent.click(getByText(defaultProps.locations[0].children[0].name));
 
     fireEvent.click(getByRole('button', { name: /back/i }));
-    const paragraph = getByText('Please confirm exiting without saving this Access Point page.');
+    const paragraph = getByText(/Please confirm leaving without saving this access point page/);
     expect(paragraph).toBeVisible();
 
     fireEvent.click(getByRole('button', { name: /save/i }));
     fireEvent.click(getByRole('button', { name: /back/i }));
   });
 
-  it('Confirm leave form Modal should not be visible if firmware is saved and User clicks back', async () => {
+  it('Confirm leave page Modal should not be visible if firmware is saved and User clicks back', async () => {
     const { getByRole, getByText } = render(
       <MemoryRouter initialEntries={['/network/access-points/1/general']}>
         <Route path="/network/access-points/:id/:tab">
@@ -270,9 +346,7 @@ describe('<AccessPointDetails />', () => {
     fireEvent.click(getByText(firmware[1].versionName));
 
     fireEvent.click(getByRole('button', { name: /back/i }));
-    expect(
-      getByText('Please confirm exiting without saving this Access Point page.')
-    ).toBeVisible();
+    expect(getByText(/Please confirm leaving without saving this access point page/)).toBeVisible();
 
     fireEvent.click(getByRole('button', { name: /cancel/i }));
     fireEvent.click(getByRole('button', { name: /download Download, Flash, and Reboot/i }));
@@ -292,7 +366,7 @@ describe('<AccessPointDetails />', () => {
     expect(window.location.pathname).toEqual('/');
   });
 
-  it('URL should change when clicking the ok button when Leave Page modal appears', () => {
+  it('URL should change when clicking the leave page button when Leave Page modal appears', () => {
     const { getByRole, getByPlaceholderText } = render(
       <MemoryRouter initialEntries={['/network/access-points/1/general']}>
         <Route path="/network/access-points/:id/:tab">
@@ -306,7 +380,7 @@ describe('<AccessPointDetails />', () => {
     });
 
     fireEvent.click(getByRole('button', { name: /back/i }));
-    fireEvent.click(getByRole('button', { name: /ok/i }));
+    fireEvent.click(getByRole('button', { name: /leave page/i }));
     expect(window.location.pathname).toEqual('/');
   });
 

--- a/src/containers/AddProfile/index.js
+++ b/src/containers/AddProfile/index.js
@@ -271,11 +271,15 @@ const AddProfile = ({
           onCancel={() => setConfirmModal(false)}
           onSuccess={() => history.push(routes.profiles)}
           visible={confirmModal}
-          buttonText="Back"
-          title="Leave Form?"
-          content={<p>Please confirm exiting without saving this Wireless Profile form. </p>}
+          buttonText="Leave Page"
+          title="Leave Page?"
+          content={
+            <p>
+              You have unsaved changes. Please confirm leaving without saving this wireless profile
+              page:
+            </p>
+          }
         />
-
         <Form
           {...pageLayout}
           form={form}

--- a/src/containers/ProfileDetails/index.js
+++ b/src/containers/ProfileDetails/index.js
@@ -253,9 +253,14 @@ const ProfileDetails = ({
         onCancel={() => setConfirmModal(false)}
         onSuccess={() => history.push(routes.profiles)}
         visible={confirmModal}
-        buttonText="Back"
-        title="Leave Form?"
-        content={<p>Please confirm exiting without saving this Profile form. </p>}
+        buttonText="Leave Page"
+        title="Leave Page?"
+        content={
+          <p>
+            You have unsaved changes. Please confirm leaving without saving this wireless profile
+            page:
+          </p>
+        }
       />
 
       <Form

--- a/src/containers/ProfileDetails/tests/index.test.js
+++ b/src/containers/ProfileDetails/tests/index.test.js
@@ -174,7 +174,7 @@ describe('<ProfileDetails />', () => {
     });
   });
 
-  it('URL should changes to /profiles when back button is clicked', async () => {
+  it('URL should change when back button is clicked', async () => {
     const { getByRole } = render(
       <Router>
         <ProfileDetails {...mockSsid} />
@@ -182,7 +182,7 @@ describe('<ProfileDetails />', () => {
     );
     fireEvent.click(getByRole('button', { name: /back/i }));
     await waitFor(() => {
-      expect(window.location.pathname).toEqual(ROUTES.profiles);
+      expect(window.location.pathname).toEqual('/');
     });
   });
 

--- a/src/containers/ProfileDetails/tests/index.test.js
+++ b/src/containers/ProfileDetails/tests/index.test.js
@@ -154,7 +154,7 @@ describe('<ProfileDetails />', () => {
     );
     fireEvent.change(getByLabelText('Profile Name'), { target: { value: 'test' } });
     fireEvent.click(getByRole('button', { name: /back/i }));
-    const paragraph = getByText('Please confirm exiting without saving this Profile form.');
+    const paragraph = getByText(/Please confirm leaving without saving this wireless profile page/);
     expect(paragraph).toBeVisible();
   });
 
@@ -166,11 +166,11 @@ describe('<ProfileDetails />', () => {
     );
     fireEvent.change(getByLabelText('Profile Name'), { target: { value: 'test' } });
     fireEvent.click(getByRole('button', { name: /back/i }));
-    expect(getByText('Leave Form?')).toBeVisible();
+    expect(getByText('Leave Page?')).toBeVisible();
     fireEvent.click(getByRole('button', { name: 'Cancel' }));
 
     await waitFor(() => {
-      expect(queryByText('Leave Form?')).not.toBeInTheDocument();
+      expect(queryByText('Leave Page?')).not.toBeInTheDocument();
     });
   });
 
@@ -186,7 +186,7 @@ describe('<ProfileDetails />', () => {
     });
   });
 
-  it('Back button click on Leave Form should chnages URL to /Profiles', async () => {
+  it('Back button click on Leave Page should changes URL to /Profiles', async () => {
     const { getByRole, getByText, getByLabelText } = render(
       <Router>
         <ProfileDetails {...mockSsid} />
@@ -194,8 +194,8 @@ describe('<ProfileDetails />', () => {
     );
     fireEvent.change(getByLabelText('Profile Name'), { target: { value: 'test' } });
     fireEvent.click(getByRole('button', { name: /back/i }));
-    expect(getByText('Leave Form?')).toBeVisible();
-    fireEvent.click(getByRole('button', { name: 'Back' }));
+    expect(getByText('Leave Page?')).toBeVisible();
+    fireEvent.click(getByRole('button', { name: 'Leave Page' }));
 
     await waitFor(() => {
       expect(window.location.pathname).toEqual(ROUTES.profiles);


### PR DESCRIPTION
JIRA: [WIFI-2413](https://telecominfraproject.atlassian.net/browse/WIFI-2413)

## Description
*Summary of this PR*
Calling the update equipment API in quick succession with the same profile, causes the cloud to push the profiles twice and results in duplicate VifC ssid and VifS failure. To fix, made the saved button disabled when form is untouched. 

- Fixed null check on `renderBandwidthLabels` function
- Improved phrasing on "Leave Page" modals

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/125119309-e8dae600-e0be-11eb-9dc9-174afd20f942.png)
![image](https://user-images.githubusercontent.com/55258316/125119341-f55f3e80-e0be-11eb-8d89-7a8e468d4604.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/125119188-bcbf6500-e0be-11eb-9549-0b6b362e1038.png)
![image](https://user-images.githubusercontent.com/55258316/125119223-c779fa00-e0be-11eb-93c8-067c62bd0532.png)
![image](https://user-images.githubusercontent.com/55258316/125119241-d2348f00-e0be-11eb-89ad-c1b7aa5200e9.png)
