### PR TITLE
hotfix/RfProfileCleanup : Cleanup input ranges on Rf profile

### DIFF
--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -672,8 +672,8 @@ const General = ({
             renderInputItem,
             {
               min: -100,
-              max: 100,
-              error: '-100 - 100 dBm',
+              max: -40,
+              error: '-100 - -40 dBm',
               addOnText: 'dBm',
               mapName: 'radioMap',
             }

--- a/src/containers/AccessPointDetails/components/General/tests/index.test.js
+++ b/src/containers/AccessPointDetails/components/General/tests/index.test.js
@@ -115,7 +115,7 @@ describe('<General />', () => {
     fireEvent.click(getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - -40 dBm')).toBeVisible();
     });
   });
   it('error if the probe response threshold exceeds bounds for the 5GHz (U) setting', async () => {
@@ -129,7 +129,7 @@ describe('<General />', () => {
     fireEvent.click(getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - -40 dBm')).toBeVisible();
     });
   });
   it('error if the probe response threshold exceeds bounds for the 5GHz (L) setting', async () => {
@@ -143,7 +143,7 @@ describe('<General />', () => {
     fireEvent.click(getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - -40 dBm')).toBeVisible();
     });
   });
 

--- a/src/containers/ProfileDetails/components/RF/index.js
+++ b/src/containers/ProfileDetails/components/RF/index.js
@@ -127,16 +127,21 @@ const RFForm = ({ form, details, extraFields }) => {
     >
       {({ getFieldValue }) => {
         const field = Object.keys(dependencies).find(
-          i => getFieldValue(['rfConfigMap', key, i]) !== dependencies[i]
+          i => getFieldValue(['rfConfigMap', key, i]) === dependencies[i]
         );
         const value = getFieldValue(['rfConfigMap', key, field]);
+        let formattedValue = '';
+        if (value === 'true' || value === 'false') {
+          formattedValue = value === 'true' ? 'enabled' : 'disabled';
+        } else {
+          formattedValue = `value: ${startCase(value)}`;
+        }
+
         return !field ? (
           inputField
         ) : (
           <DisabledText
-            title={`The ${radioTypes[key]} radio has "${startCase(field)}" ${
-              value === 'true' ? 'enabled' : 'disabled'
-            }.`}
+            title={`The ${radioTypes[key]} radio has "${startCase(field)}" ${formattedValue}.`}
           />
         );
       }}
@@ -170,7 +175,7 @@ const RFForm = ({ form, details, extraFields }) => {
           {({ getFieldValue }) => {
             return Object.keys(options.dependencies).every(key =>
               currentRadios.some(
-                radio => getFieldValue(['rfConfigMap', radio, key]) === options.dependencies[key]
+                radio => getFieldValue(['rfConfigMap', radio, key]) !== options.dependencies[key]
               )
             )
               ? Wrapper
@@ -284,7 +289,6 @@ const RFForm = ({ form, details, extraFields }) => {
                 <Option value="modeN">N</Option>
                 {key === 'is2dot4GHz' && (
                   <>
-                    <Option value="modeB">B</Option>
                     <Option value="modeG">G</Option>
                   </>
                 )}
@@ -346,7 +350,7 @@ const RFForm = ({ form, details, extraFields }) => {
               <Option value="rate24mbps">24</Option>
             </Select>
           ),
-          dependencies: { autoCellSizeSelection: 'false' },
+          dependencies: { autoCellSizeSelection: 'true' },
         })}
         {renderItem('Multicast Rate (Mbps)', ['multicastRate'], renderOptionItem, {
           dropdown: (
@@ -362,14 +366,14 @@ const RFForm = ({ form, details, extraFields }) => {
               <Option value="rate54mbps">54</Option>
             </Select>
           ),
-          dependencies: { autoCellSizeSelection: 'false' },
+          dependencies: { autoCellSizeSelection: 'true' },
         })}
         {renderItem('Probe Response Threshold', ['probeResponseThresholdDb'], renderInputItem, {
           min: -100,
-          max: 100,
-          error: '-100 - 100 dBm',
+          max: -40,
+          error: '-100 - -40 dBm',
           addOnText: 'dBm',
-          dependencies: { autoCellSizeSelection: 'false' },
+          dependencies: { autoCellSizeSelection: 'true' },
         })}
         {renderItem(
           'Client Disconnect Threshold',
@@ -380,19 +384,19 @@ const RFForm = ({ form, details, extraFields }) => {
             max: 0,
             error: '-100 - 0 dBm',
             addOnText: 'dBm',
-            dependencies: { autoCellSizeSelection: 'false' },
+            dependencies: { autoCellSizeSelection: 'true' },
           }
         )}
         {renderItem('Max EIRP Tx Power', ['useMaxTxPower'], renderOptionItem, {
           dropdown: defaultOptions,
-          dependencies: { autoCellSizeSelection: 'false' },
+          dependencies: { autoCellSizeSelection: 'true' },
         })}
         {renderItem('EIRP Tx Power', ['eirpTxPower'], renderInputItem, {
           min: 1,
           max: 32,
           error: '1 - 32 dBm',
           addOnText: 'dBm',
-          dependencies: { autoCellSizeSelection: 'false', useMaxTxPower: 'false' },
+          dependencies: { autoCellSizeSelection: 'true', useMaxTxPower: 'true' },
         })}
         <p>Active Scan Setting:</p>
         {renderItem('Enable', ['activeScanSettings', 'enabled'], renderOptionItem, {
@@ -403,9 +407,9 @@ const RFForm = ({ form, details, extraFields }) => {
           ['activeScanSettings', 'scanFrequencySeconds'],
           renderInputItem,
           {
-            min: 0,
+            min: 10,
             max: 100,
-            error: '0 - 100 seconds',
+            error: '10 - 100 seconds',
             addOnText: 'sec',
           }
         )}
@@ -414,9 +418,9 @@ const RFForm = ({ form, details, extraFields }) => {
           ['activeScanSettings', 'scanDurationMillis'],
           renderInputItem,
           {
-            min: 0,
+            min: 50,
             max: 100,
-            error: '0 - 100 milliseconds',
+            error: '50 - 100 milliseconds',
             addOnText: 'ms',
           }
         )}

--- a/src/containers/ProfileDetails/components/RF/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/RF/tests/index.test.js
@@ -111,7 +111,7 @@ describe('<RFForm />', () => {
 
       expect(queryByText('0 - 100')).not.toBeInTheDocument();
       expect(queryByText('0 - 65535 (Bytes)')).not.toBeInTheDocument();
-      expect(queryByText('-100 - 100 dBm')).not.toBeInTheDocument();
+      expect(queryByText('-100 - -40 dBm')).not.toBeInTheDocument();
       expect(queryByText('0 - 100 dBm')).not.toBeInTheDocument();
       expect(queryByText('0 - 100 sec')).not.toBeInTheDocument();
       expect(queryByText('0 - 100 ms')).not.toBeInTheDocument();
@@ -310,7 +310,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - 0 dBm')).toBeVisible();
     });
   });
 
@@ -331,7 +331,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - 0 dBm')).toBeVisible();
     });
   });
 
@@ -352,7 +352,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - 0 dBm')).toBeVisible();
     });
   });
 
@@ -373,7 +373,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - 0 dBm')).toBeVisible();
     });
   });
 
@@ -395,7 +395,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - -40 dBm')).toBeVisible();
     });
   });
 
@@ -416,7 +416,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - -40 dBm')).toBeVisible();
     });
   });
 
@@ -437,7 +437,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - -40 dBm')).toBeVisible();
     });
   });
 
@@ -458,7 +458,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('-100 - 100 dBm')).toBeVisible();
+      expect(getByText('-100 - -40 dBm')).toBeVisible();
     });
   });
   // test Client Disconnect Threshold invalid inputs
@@ -647,7 +647,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('0 - 100 seconds')).toBeVisible();
+      expect(getByText('10 - 100 seconds')).toBeVisible();
     });
   });
 
@@ -668,7 +668,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('0 - 100 seconds')).toBeVisible();
+      expect(getByText('10 - 100 seconds')).toBeVisible();
     });
   });
 
@@ -689,7 +689,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('0 - 100 seconds')).toBeVisible();
+      expect(getByText('10 - 100 seconds')).toBeVisible();
     });
   });
 
@@ -710,7 +710,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('0 - 100 seconds')).toBeVisible();
+      expect(getByText('10 - 100 seconds')).toBeVisible();
     });
   });
   // test Scan Duration invalid inputs
@@ -731,7 +731,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('0 - 100 milliseconds')).toBeVisible();
+      expect(getByText('50 - 100 milliseconds')).toBeVisible();
     });
   });
 
@@ -752,7 +752,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('0 - 100 milliseconds')).toBeVisible();
+      expect(getByText('50 - 100 milliseconds')).toBeVisible();
     });
   });
 
@@ -773,7 +773,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('0 - 100 milliseconds')).toBeVisible();
+      expect(getByText('50 - 100 milliseconds')).toBeVisible();
     });
   });
 
@@ -794,7 +794,7 @@ describe('<RFForm />', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('0 - 100 milliseconds')).toBeVisible();
+      expect(getByText('50 - 100 milliseconds')).toBeVisible();
     });
   });
 

--- a/src/containers/ProfileDetails/tests/constants.js
+++ b/src/containers/ProfileDetails/tests/constants.js
@@ -488,10 +488,10 @@ export const mockRf = {
       renderInput: 'renderInputItem',
       options: {
         min: -100,
-        max: 100,
-        error: '-100 - 100 dBm',
+        max: 0,
+        error: '-100 - 0 dBm',
         addOnText: 'dBm',
-        dependencies: { autoCellSizeSelection: 'false' },
+        dependencies: { autoCellSizeSelection: 'true' },
       },
     },
   ],


### PR DESCRIPTION
NO-JIRA

## Description
*Summary of this PR*
Changed input field ranges on RF profile:

- Probe Response Threshold: -100 - 100 dm →  -100 - -40 dm
- Rx Cell Size: -100 - 100 dm →  -100 - 0 dm
- Auto Cell Size Selection:  Now shows 'N/A' when radio-mode 'modeA' is selected
- Removed 'modeB' option from 2.4Ghz Radio Mode
- Active Scan Setting → Scan Frequency:  0 - 100 seconds →   10 - 100
- Active Scan Setting → Scan Duration:  0 - 100 milliseconds →   50 - 100

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*