### PR TITLE
Bugfix/NOJIRA: Upgrade Firmware

### DIFF
--- a/src/containers/AccessPointDetails/components/Firmware/index.js
+++ b/src/containers/AccessPointDetails/components/Firmware/index.js
@@ -108,9 +108,10 @@ const Firmware = ({
   const getRebootStatus = () => updateInProgressStates.has(status?.upgradeState);
 
   const getUpgradePercentage = value => {
-    if (value.includes('download')) return 30;
-    if (value.includes('apply')) return 60;
-    if (value.includes('reboot')) return 90;
+    if (value.includes('download_initiated')) return 20;
+    if (value.includes('download_complete')) return 40;
+    if (value.includes('apply_initiated')) return 60;
+    if (value.includes('apply_complete')) return 80;
     return 100;
   };
 

--- a/src/containers/AccessPointDetails/components/Firmware/index.js
+++ b/src/containers/AccessPointDetails/components/Firmware/index.js
@@ -26,7 +26,6 @@ const updateInProgressStates = new Set([
   'download_complete',
   'apply_initiated',
   'applying',
-  'apply_failed',
   'apply_complete',
   'reboot_initiated',
   'rebooting',
@@ -90,6 +89,7 @@ const Firmware = ({
     if (value === 'download_complete') return 'Download Completed';
     if (value === 'apply_initiated') return 'Initiated Firmware Flash';
     if (value === 'apply_complete') return 'Flashed to Inactive Bank';
+    if (value === 'apply_failed') return 'Upgrade Failed';
     if (value === 'applying') return 'Flashing Firmware';
     if (value === 'undefined') return 'Stable';
     return value.toUpperCase().replace(/_/g, ' ');
@@ -97,17 +97,15 @@ const Firmware = ({
 
   const alertColor = value => {
     if (value === 'out_of_date') return 'warning';
+    if (value === 'apply_failed') return 'error';
     if (value === null || value === 'up_to_date') return 'success';
-    if (value === 'download_complete' || value === 'apply_failed') return 'processing';
+    if (value === 'download_complete') return 'processing';
     return 'default';
   };
 
   const status = data?.status?.firmware?.detailsJSON || {};
 
-  const getRebootStatus = () => {
-    if (updateInProgressStates.has(status?.upgradeState)) return true;
-    return false;
-  };
+  const getRebootStatus = () => updateInProgressStates.has(status?.upgradeState);
 
   const getUpgradePercentage = value => {
     if (value.includes('download')) return 30;
@@ -156,12 +154,7 @@ const Firmware = ({
         </WithRoles>
 
         <Card title="Firmware">
-          <Item label="Active Version">
-            {status.activeSwVersion}
-            <Tag className={styles.UpgradeState} color={alertColor(status.upgradeState)}>
-              {alertText(status.upgradeState)}
-            </Tag>
-          </Item>
+          <Item label="Active Version">{status.activeSwVersion}</Item>
 
           <Item label="Inactive Version">
             {status.alternateSwVersion}
@@ -176,12 +169,20 @@ const Firmware = ({
           </Item>
         </Card>
         <WithRoles>
-          <Card title="Upgrade">
+          <Card
+            title={
+              <>
+                Upgrade
+                <Tag className={styles.UpgradeState} color={alertColor(status.upgradeState)}>
+                  {alertText(status.upgradeState)}
+                </Tag>
+              </>
+            }
+          >
             {getRebootStatus() ? (
               <>
                 <div>
-                  Upgrade {status?.targetSwVersion && `to ${status?.targetSwVersion}`} already in
-                  progress
+                  Upgrade {status?.targetSwVersion && `to ${status?.targetSwVersion}`} in progress
                 </div>
                 <Progress percent={getUpgradePercentage(status?.upgradeState)} />
               </>
@@ -196,9 +197,13 @@ const Firmware = ({
                         placeholder="Select a version to apply..."
                       >
                         {Object.keys(firmware).map(i => (
-                          <Option key={firmware[i].id} value={firmware[i].id}>
-                            {firmware[i].versionName}
-                          </Option>
+                          <>
+                            {status?.activeSwVersion !== firmware[i].versionName && (
+                              <Option key={firmware[i].id} value={firmware[i].id}>
+                                {firmware[i].versionName}
+                              </Option>
+                            )}
+                          </>
                         ))}
                       </Select>
                     </Item>

--- a/src/containers/AccessPointDetails/components/Firmware/index.js
+++ b/src/containers/AccessPointDetails/components/Firmware/index.js
@@ -110,8 +110,11 @@ const Firmware = ({
   const getUpgradePercentage = value => {
     if (value.includes('download_initiated')) return 20;
     if (value.includes('download_complete')) return 40;
+    if (value.includes('download')) return 50;
     if (value.includes('apply_initiated')) return 60;
     if (value.includes('apply_complete')) return 80;
+    if (value.includes('apply')) return 80;
+    if (value.includes('reboot')) return 90;
     return 100;
   };
 


### PR DESCRIPTION
NOJIRA

## Description
Thu Jul 15

- There is a case where the AP gets stuck in the `apply_failed` state. In this case, we want the user to be able to reattempt the firmware upgrade manually.
- Move the current upgrade status stag to the Upgrade card.
- Don't show current firmware in the target version list.
- Will be affected until WIFI-2650 is fixed where `apply_failed` is set erroneously but not breaking issue

### Before this PR
![Screen Shot 2021-07-15 at 3 15 29 PM](https://user-images.githubusercontent.com/69811026/125844714-095d77f6-5624-4f1f-8853-e70735a00d30.png)


### After this PR
<img width="1538" alt="Screen Shot 2021-07-15 at 3 15 36 PM" src="https://user-images.githubusercontent.com/69811026/125844728-2a1499b5-6b99-4a84-ad25-a6665eeda5d0.png">
