### PR TITLE
hotfix/PasspointProviderIdNaiFields: Empty strings instead of null for Nai fields

### DIFF
--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -367,6 +367,9 @@ export const formatProviderProfileForm = values => {
     ];
   }
 
+  formattedData.osuNaiShared = '';
+  formattedData.osuNaiStandalone = '';
+
   return formattedData;
 };
 


### PR DESCRIPTION
NO-JIRA

## Description
*Summary of this PR*
Following fields in provider ID profile are required by the AP for the Hotspot20_OSU_Providers table in order to come up properly:
- osuNaiStandalone
- osuNaiShared

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*