### PR TITLE
hotfix/ApDetailsSelectedProfiles: Fixed selectedProfiles state

### DIFF
--- a/src/containers/AccessPointDetails/components/General/constants.js
+++ b/src/containers/AccessPointDetails/components/General/constants.js
@@ -13,20 +13,9 @@ export const USER_FRIENDLY_RATES = {
   rate54mbps: '54',
 };
 
-export const ALLOWED_CHANNELS_STEP = {
-  is20MHz: 1,
-  is40MHz: 2,
-  is80MHz: 4,
-  is160MHz: 8,
-};
-
 export const USER_FRIENDLY_BANDWIDTHS = {
   is20MHz: '20MHz',
   is40MHz: '40MHz',
   is80MHz: '80MHz',
   is160MHz: '160MHz',
 };
-
-export const MAX_CHANNEL_WIDTH_40MHZ_OR_80MHZ = 157;
-
-export const MAX_CHANNEL_WIDTH_160MHZ = 100;

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -68,7 +68,7 @@ const General = ({
     },
   ];
 
-  const [selectedProfile, setSelectedProfile] = useState(data.profile);
+  const [selectedProfile, setSelectedProfile] = useState(null);
 
   const childProfiles = useMemo(() => {
     const result = {
@@ -86,6 +86,10 @@ const General = ({
     }
     return result;
   }, [selectedProfile]);
+
+  useEffect(() => {
+    setSelectedProfile(data?.profile);
+  }, [data.profile]);
 
   const handleProfileChange = value => {
     const i = profiles.find(o => {
@@ -116,7 +120,6 @@ const General = ({
       };
 
       currentRadios.forEach(radio => {
-        const isEnabled = childProfiles.rf?.[0]?.details?.rfConfigMap[radio].autoChannelSelection;
         formData.advancedRadioMap[radio] = {
           radioAdminState: advancedRadioMap[radio]?.radioAdminState || 'disabled',
           deauthAttackDetection: advancedRadioMap[radio]?.deauthAttackDetection ? 'true' : 'false',
@@ -140,14 +143,6 @@ const General = ({
           rxCellSizeDb: {
             value: radioMap[radio]?.rxCellSizeDb?.value || 0,
           },
-          [isEnabled ? 'channelNumber' : 'manualChannelNumber']: isEnabled
-            ? radioMap[radio]?.channelNumber
-            : radioMap[radio]?.manualChannelNumber,
-
-          [isEnabled ? 'backupChannelNumber' : 'manualBackupChannelNumber']: isEnabled
-            ? radioMap[radio]?.backupChannelNumber
-            : radioMap[radio]?.manualBackupChannelNumber,
-
           probeResponseThresholdDb: {
             value: radioMap[radio]?.probeResponseThresholdDb?.value || 0,
           },
@@ -164,6 +159,29 @@ const General = ({
       form.setFieldsValue({ ...formData });
     }
   }, [data]);
+
+  useEffect(() => {
+    if (data?.details) {
+      const currentRadios = Object.keys(advancedRadioMap);
+      const formData = {
+        radioMap: {},
+      };
+      currentRadios.forEach(radio => {
+        const isEnabled =
+          childProfiles.rf?.[0]?.details?.rfConfigMap?.[radio]?.autoChannelSelection;
+        formData.radioMap[radio] = {
+          [isEnabled ? 'channelNumber' : 'manualChannelNumber']: isEnabled
+            ? radioMap[radio]?.channelNumber
+            : radioMap[radio]?.manualChannelNumber,
+          [isEnabled ? 'backupChannelNumber' : 'manualBackupChannelNumber']: isEnabled
+            ? radioMap[radio]?.backupChannelNumber
+            : radioMap[radio]?.manualBackupChannelNumber,
+        };
+      });
+
+      form.setFieldsValue({ ...formData });
+    }
+  }, [selectedProfile]);
 
   const handleOnSave = () => {
     form
@@ -559,9 +577,13 @@ const General = ({
         </Item>
 
         <Item label="RF Profile">
-          <Link to={`${routes.profiles}/${childProfiles.rf?.[0]?.id}`}>
-            {childProfiles.rf?.[0]?.name || 'N/A'}
-          </Link>
+          {childProfiles.rf?.[0]?.name ? (
+            <Link to={`${routes.profiles}/${childProfiles.rf?.[0]?.id}`}>
+              {childProfiles.rf?.[0]?.name}
+            </Link>
+          ) : (
+            'N/A'
+          )}
         </Item>
         <Item label="Summary">
           <Item>

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -62,7 +62,7 @@ const General = ({
     },
   ];
 
-  const [selectedProfile, setSelectedProfile] = useState(null);
+  const [selectedProfile, setSelectedProfile] = useState(data.profile);
 
   const childProfiles = useMemo(() => {
     const result = {

--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -11,13 +11,7 @@ import Tooltip from 'components/Tooltip';
 
 import { sortRadioTypes } from 'utils/sortRadioTypes';
 import { pageLayout } from 'utils/form';
-import {
-  USER_FRIENDLY_RATES,
-  USER_FRIENDLY_BANDWIDTHS,
-  ALLOWED_CHANNELS_STEP,
-  MAX_CHANNEL_WIDTH_40MHZ_OR_80MHZ,
-  MAX_CHANNEL_WIDTH_160MHZ,
-} from './constants';
+import { USER_FRIENDLY_RATES, USER_FRIENDLY_BANDWIDTHS } from './constants';
 
 import styles from '../../index.module.scss';
 
@@ -364,7 +358,7 @@ const General = ({
         <div className={styles.InlineDiv}>
           {sortRadioTypes(Object.keys(radioMap)).map(key => {
             const isEnabled = childProfiles.rf?.[0]?.details?.rfConfigMap[key].autoChannelSelection;
-            const bandwidth = childProfiles.rf?.[0]?.details?.rfConfigMap[key].channelBandwidth;
+
             let channel;
             if (label === 'Active Channel') {
               channel = isEnabled
@@ -403,7 +397,7 @@ const General = ({
 
             const powerLevels = data?.details?.radioMap?.[key]?.allowedChannelsPowerLevels ?? [];
 
-            let allowedChannels = powerLevels
+            const allowedChannels = powerLevels
               .filter(item => {
                 if (channel.dataIndex === 'manualBackupChannelNumber') {
                   return !item.dfs;
@@ -411,17 +405,7 @@ const General = ({
                 return item;
               })
               .map(item => item?.channelNumber)
-              .sort((a, b) => a - b)
-              .filter((__, index) => index % ALLOWED_CHANNELS_STEP[bandwidth] === 0);
-
-            if (bandwidth !== 'is20MHz') {
-              allowedChannels = allowedChannels.filter(item => {
-                if (bandwidth === 'is160MHz') {
-                  return item <= MAX_CHANNEL_WIDTH_160MHZ;
-                }
-                return item <= MAX_CHANNEL_WIDTH_40MHZ_OR_80MHZ;
-              });
-            }
+              .sort((a, b) => a - b);
 
             return (
               <Item


### PR DESCRIPTION
NO-JIRA

## Description
*Summary of this PR*

Bug: RF profile is displayed as NA and Summary table is empty on page load, even though a valid RF profile is configured.

- Fixed selectedProfiles state due to new skeleton loading
- Fixed channel input on selectedProfile change (previously it would not update field value)
- Removed channel bandwidth validation on Channel input 

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*