### PR TITLE
hotfix/SsidProxyArp: Hide Proxy-ARP field

### DIFF
--- a/src/containers/ProfileDetails/components/SSID/index.js
+++ b/src/containers/ProfileDetails/components/SSID/index.js
@@ -475,7 +475,7 @@ const SSIDForm = ({
             );
           }}
         </Item>
-        <Item name="enableProxyArpForHotspot" label="Proxy-ARP">
+        <Item name="enableProxyArpForHotspot" label="Proxy-ARP" hidden>
           {radioOptions}
         </Item>
       </Card>


### PR DESCRIPTION
NO-JIRA

## Description
*Summary of this PR*
Hide Proxy-ARP field on SSID profile as AP needs to have proxy ARP enabled for WIFI 6 to work properly. This field will always be internally set to enabled. 

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*