### PR TITLE
Bugfix/NOJIRA: remove permieter detection

### DIFF
--- a/src/containers/AccessPointDetails/components/General/index.js
+++ b/src/containers/AccessPointDetails/components/General/index.js
@@ -146,7 +146,6 @@ const General = ({
           eirpTxPower: {
             value: radioMap[radio]?.eirpTxPower?.value || 0,
           },
-          perimeterDetectionEnabled: radioMap[radio]?.perimeterDetectionEnabled ? 'true' : 'false',
         };
       });
 
@@ -697,15 +696,6 @@ const General = ({
             addOnText: 'dBm',
             mapName: 'radioMap',
           })}
-
-          <p>Radio Resource Management:</p>
-          {renderItem(
-            'Perimeter Detection',
-            radioMap,
-            ['perimeterDetectionEnabled'],
-            renderOptionItem,
-            { dropdown: defaultOptionsBoolean, mapName: 'radioMap' }
-          )}
 
           <p>Steering Threshold:</p>
           {renderItem(


### PR DESCRIPTION
NOJIRA

## Description
Thu Jul 22

- Perimeter Detection field has no placeholder on AP. This field can be removed from the UI for now

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*