### PR TITLE
hotfix/BulkEditAllowedChannels: Added allowed channels to bulk-edit table

### DIFF
--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/index.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/index.js
@@ -1,10 +1,19 @@
 import React, { useContext, useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Form, Input } from 'antd';
+
+import ThemeContext from 'contexts/ThemeContext';
+
 import { EditableContext } from '../EditableRow';
+
 import styles from './index.module.scss';
 
 const { Item } = Form;
+
+const isNumeric = value => {
+  return /^\s?\d+$/.test(value);
+};
+
 export const EditableCell = ({
   title,
   editable,
@@ -18,6 +27,8 @@ export const EditableCell = ({
   const inputRef = useRef();
   const form = useContext(EditableContext);
 
+  const { radioTypes } = useContext(ThemeContext);
+
   useEffect(() => {
     if (editing) {
       inputRef.current.focus();
@@ -25,59 +36,95 @@ export const EditableCell = ({
   }, [editing]);
 
   const toggleEdit = () => {
-    setEditing(!editing);
-    form.setFieldsValue({
-      [dataIndex]: record[dataIndex],
-    });
+    form
+      .validateFields()
+      .then(() => {
+        setEditing(!editing);
+        form.setFieldsValue({
+          [dataIndex]: record[dataIndex],
+        });
+      })
+      .catch(() => {});
   };
 
   const validateInput = (input, key) => {
-    if (
-      key === 'probeResponseThreshold' ||
-      key === 'clientDisconnectThreshold' ||
-      key === 'cellSize'
-    ) {
-      return input >= -100 && input <= 100;
+    if (key === 'clientDisconnectThreshold' || key === 'cellSize') {
+      return input >= -100 && input <= 0;
     }
-    if (key === 'snrDrop' || key === 'minLoad') {
-      return input >= 0 && input <= 100;
+
+    if (key === 'probeResponseThreshold') {
+      return input >= -100 && input <= -40;
     }
-    return input >= -1 && input <= 165;
+
+    return input >= 0 && input <= 100;
   };
 
   const validateChannelInput = key => {
-    if (key === 'manualChannelNumber') {
-      return (
-        form
-          .getFieldValue('manualChannelNumber')
-          .split(',')
-          .filter(channel => record.manualBackupChannelNumber.includes(parseInt(channel, 10)))
-          .length === 0
-      );
-    }
+    const dependentKey =
+      key === 'manualChannelNumber' ? 'manualBackupChannelNumber' : 'manualChannelNumber';
 
-    return (
-      form
-        .getFieldValue('manualBackupChannelNumber')
-        .split(',')
-        .filter(channel => record.manualChannelNumber.includes(parseInt(channel, 10))).length === 0
-    );
+    const input = form.getFieldValue(key).split(',');
+
+    return Promise.all(
+      input.map((channel, i) => {
+        const channels = record.allowedChannels[i]
+          .filter(item => {
+            if (key === 'manualBackupChannelNumber') {
+              return !item.dfs;
+            }
+            return item;
+          })
+          .map(item => item?.channelNumber, 10)
+          .sort((a, b) => a - b);
+
+        const parsedChannel = parseInt(channel, 10);
+
+        if (!isNumeric(channel)) {
+          return Promise.reject(
+            new Error(`Enter a valid channel number for ${radioTypes[record.radioMap[i]]}`)
+          );
+        }
+
+        if (!channels.includes(parsedChannel)) {
+          return Promise.reject(
+            new Error(
+              `Allowed Channels for ${radioTypes[record.radioMap[i]]}: ${channels.join(', ')}`
+            )
+          );
+        }
+        if (record[dependentKey].includes(parsedChannel)) {
+          return Promise.reject(
+            new Error(
+              `Active and Backup channels for ${
+                radioTypes[record.radioMap[i]]
+              } radio must be different`
+            )
+          );
+        }
+        return Promise.resolve();
+      })
+    )
+      .then(() => Promise.resolve())
+      .catch(e => Promise.reject(e));
   };
 
   const errorText = key => {
-    if (
-      key === 'probeResponseThreshold' ||
-      key === 'clientDisconnectThreshold' ||
-      key === 'cellSize'
-    ) {
-      return `-100 - 100`;
+    if (key === 'clientDisconnectThreshold' || key === 'cellSize') {
+      return '-100 - 0';
+    }
+
+    if (key === 'probeResponseThreshold') {
+      return '-100 - -40';
     }
 
     if (key === 'snrDrop' || key === 'minLoad') {
       return `1 - 100`;
     }
 
-    return `1 - 165`;
+    if (key === 'manualChannelNumber') {
+      return `Enter Active Channels`;
+    }
+    return `Enter Backup Channels`;
   };
 
   const save = () => {
@@ -113,11 +160,7 @@ export const EditableCell = ({
                   dataIndex === 'manualChannelNumber' ||
                   dataIndex === 'manualBackupChannelNumber'
                 ) {
-                  if (!validateChannelInput(dataIndex)) {
-                    return Promise.reject(
-                      new Error(`Active and backup channels must be different`)
-                    );
-                  }
+                  return validateChannelInput(dataIndex);
                 }
 
                 if (!values || values.split(',').every(value => validateInput(value, dataIndex))) {
@@ -170,6 +213,7 @@ EditableCell.propTypes = {
     minLoad: PropTypes.instanceOf(Array),
     radioMap: PropTypes.instanceOf(Array),
     id: PropTypes.string,
+    allowedChannels: PropTypes.instanceOf(Array),
   }),
   handleSave: PropTypes.func,
 };

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/tests/index.test.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/components/EditableCell/tests/index.test.js
@@ -42,7 +42,7 @@ const mockProps = {
 const ENTER = { keyCode: 13 };
 
 describe('<EditableCell />', () => {
-  it('Ap data should be displayed in editable form in ant form element, when table cell is clicked.', () => {
+  it('Ap data should be displayed in editable form in ant form element, when table cell is clicked.', async () => {
     const EditableCellComp = () => {
       const [form] = Form.useForm();
       return (
@@ -58,11 +58,12 @@ describe('<EditableCell />', () => {
       `bulkEditTableCell-${mockProps.record.name}-${mockProps.dataIndex}`
     );
     fireEvent.click(tableCell);
-    const formElement = getByTestId(
-      `bulkEditFormElement-${mockProps.record.name}-${mockProps.dataIndex}`
-    );
 
-    expect(formElement).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        getByTestId(`bulkEditFormElement-${mockProps.record.name}-${mockProps.dataIndex}`)
+      ).toBeInTheDocument();
+    });
   });
 
   it('handleSave should not be called when input filed is empty and Enter key is pressed', async () => {
@@ -82,6 +83,10 @@ describe('<EditableCell />', () => {
       `bulkEditTableCell-${mockProps.record.name}-${mockProps.dataIndex}`
     );
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.record.name}-${mockProps.dataIndex}`);
+    });
     const input = getByTestId(`bulkEditFormInput-${mockProps.record.name}-${mockProps.dataIndex}`);
     fireEvent.change(input, { target: { value: '' } });
     expect(input.value).toBe('');
@@ -109,6 +114,11 @@ describe('<EditableCell />', () => {
       `bulkEditTableCell-${mockProps.record.name}-${mockProps.dataIndex}`
     );
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.record.name}-${mockProps.dataIndex}`);
+    });
+
     const input = getByTestId(`bulkEditFormInput-${mockProps.record.name}-${mockProps.dataIndex}`);
     expect(input).toBeInTheDocument();
 
@@ -140,6 +150,10 @@ describe('<EditableCell />', () => {
       `bulkEditTableCell-${mockProps.record.name}-${mockProps.dataIndex}`
     );
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.record.name}-${mockProps.dataIndex}`);
+    });
     const input = getByTestId(`bulkEditFormInput-${mockProps.record.name}-${mockProps.dataIndex}`);
     expect(input).toBeInTheDocument();
 

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/index.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/index.js
@@ -1,12 +1,19 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Table } from 'antd';
+import { Table } from 'components/Skeleton';
 import Button from 'components/Button';
 import { EditableRow } from './components/EditableRow';
 import { EditableCell } from './components/EditableCell';
 import styles from './index.module.scss';
 
-const BulkEditAPTable = ({ tableColumns, tableData, onLoadMore, isLastPage, setEditedRows }) => {
+const BulkEditAPTable = ({
+  tableColumns,
+  tableData,
+  onLoadMore,
+  isLastPage,
+  setEditedRows,
+  loading,
+}) => {
   const [bulkEditTableData, setTableData] = useState([]);
 
   useEffect(() => {
@@ -54,8 +61,10 @@ const BulkEditAPTable = ({ tableColumns, tableData, onLoadMore, isLastPage, setE
         rowClassName={styles.editableRow}
         columns={columns}
         dataSource={bulkEditTableData}
-        scroll={{ x: 1000 }}
+        scroll={{ x: 'max-content' }}
         pagination={false}
+        loading={loading}
+        rowKey="key"
       />
       {isLastPage === false && (
         <div className={styles.LoadMore}>
@@ -72,12 +81,14 @@ BulkEditAPTable.propTypes = {
   onLoadMore: PropTypes.func.isRequired,
   isLastPage: PropTypes.bool,
   setEditedRows: PropTypes.func,
+  loading: PropTypes.bool,
 };
 
 BulkEditAPTable.defaultProps = {
   tableData: [],
   isLastPage: true,
   setEditedRows: () => {},
+  loading: true,
 };
 
 export default BulkEditAPTable;

--- a/src/components/BulkEditAccessPoints/components/BulkEditAPTable/tests/index.test.js
+++ b/src/components/BulkEditAccessPoints/components/BulkEditAPTable/tests/index.test.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/extend-expect';
 
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 
 import React from 'react';
 import { render } from 'tests/utils';
@@ -73,8 +73,8 @@ const mockProps = {
   tableData: [
     {
       cellSize: [-90, -90, -90],
-      manualChannelNumber: [36, 6, 149],
-      manualBackupChannelNumber: [45, 11, 154],
+      manualChannelNumber: [6, 36, 149],
+      manualBackupChannelNumber: [11, 52, 153],
       clientDisconnectThreshold: [-90, -90, -90],
       id: '1',
       key: '1',
@@ -82,11 +82,63 @@ const mockProps = {
       name: 'AP 1',
       probeResponseThreshold: [-90, -90, -90],
       snrDrop: [30, 30, 20],
-      radioMap: ['is5GHz', 'is2dot4GHz', 'is5GHzL'],
+      radioMap: ['2.4GHz', '5GHz (L)', '5GHz (U)'],
+      allowedChannels: [
+        [
+          {
+            model_type: 'ChannelPowerLevel',
+            channelNumber: 11,
+            powerLevel: 18,
+            dfs: false,
+            channelWidth: 20,
+          },
+          {
+            model_type: 'ChannelPowerLevel',
+            channelNumber: 6,
+            powerLevel: 18,
+            dfs: false,
+            channelWidth: 20,
+          },
+        ],
+        [
+          {
+            model_type: 'ChannelPowerLevel',
+            channelNumber: 153,
+            powerLevel: 18,
+            dfs: false,
+            channelWidth: 80,
+          },
+
+          {
+            model_type: 'ChannelPowerLevel',
+            channelNumber: 149,
+            powerLevel: 18,
+            dfs: false,
+            channelWidth: 80,
+          },
+        ],
+        [
+          {
+            model_type: 'ChannelPowerLevel',
+            channelNumber: 36,
+            powerLevel: 18,
+            dfs: false,
+            channelWidth: 80,
+          },
+          {
+            model_type: 'ChannelPowerLevel',
+            channelNumber: 52,
+            powerLevel: 18,
+            dfs: true,
+            channelWidth: 80,
+          },
+        ],
+      ],
     },
   ],
   onLoadMore: jest.fn(),
   isLastPage: false,
+  loading: false,
 };
 
 describe('<BulkEditAPTableComp />', () => {
@@ -108,6 +160,10 @@ describe('<BulkEditAPTableComp />', () => {
       `bulkEditTableCell-${mockProps.tableData[0].name}-manualChannelNumber`
     );
     fireEvent.click(tableCell);
+
+    await waitFor(() =>
+      getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-manualChannelNumber`)
+    );
     const input = getByTestId(
       `bulkEditFormInput-${mockProps.tableData[0].name}-manualChannelNumber`
     );

--- a/src/components/BulkEditAccessPoints/index.js
+++ b/src/components/BulkEditAccessPoints/index.js
@@ -9,6 +9,7 @@ import { RoleProtectedBtn } from 'components/WithRoles';
 import { useHistory } from 'hooks';
 
 import BulkEditAPTable from './components/BulkEditAPTable';
+
 import styles from './index.module.scss';
 
 const BulkEditAccessPoints = ({
@@ -18,6 +19,7 @@ const BulkEditAccessPoints = ({
   onLoadMore,
   isLastPage,
   breadcrumbPath,
+  loading,
 }) => {
   const { routes } = useContext(ThemeContext);
   const { pushWithSearch } = useHistory();
@@ -32,7 +34,7 @@ const BulkEditAccessPoints = ({
   ));
 
   return (
-    <div>
+    <>
       <Button
         title="back"
         onClick={handleBackClick}
@@ -43,8 +45,8 @@ const BulkEditAccessPoints = ({
       </Button>
 
       <div className={styles.innerContainer}>
-        <div className={styles.innerText}>
-          Bulk Edit Access Points:
+        <div>
+          <h1>Bulk Edit Access Points</h1>
           <Breadcrumb separator=">">{breadCrumbs}</Breadcrumb>
         </div>
         <RoleProtectedBtn
@@ -65,8 +67,10 @@ const BulkEditAccessPoints = ({
         setEditedRows={setEditedRows}
         onLoadMore={onLoadMore}
         isLastPage={isLastPage}
+        loading={loading}
+        onSaveChanges={onSaveChanges}
       />
-    </div>
+    </>
   );
 };
 
@@ -77,12 +81,14 @@ BulkEditAccessPoints.propTypes = {
   onLoadMore: PropTypes.func.isRequired,
   isLastPage: PropTypes.bool,
   breadcrumbPath: PropTypes.instanceOf(Array),
+  loading: PropTypes.bool,
 };
 
 BulkEditAccessPoints.defaultProps = {
   tableData: [],
   isLastPage: true,
   breadcrumbPath: [],
+  loading: true,
 };
 
 export default BulkEditAccessPoints;

--- a/src/components/BulkEditAccessPoints/index.module.scss
+++ b/src/components/BulkEditAccessPoints/index.module.scss
@@ -1,23 +1,16 @@
 .backButton {
   margin: 15px;
 }
+
 .innerContainer {
   display: flex;
-  align-items: center;
   justify-content: space-between;
   padding: 15px;
   margin-bottom: 15px;
   @media screen and (max-width: 575px) {
     flex-direction: column;
   }
-}
-.innerText {
-  font-weight: 400;
-  font-size: 18px;
-  height: auto;
-  margin: 0px;
-  @media screen and (max-width: 575px) {
-    line-height: 1.3;
-    margin-bottom: 12px;
+  :global(.ant-breadcrumb) {
+    font-size: 18px;
   }
 }

--- a/src/components/BulkEditAccessPoints/tests/index.test.js
+++ b/src/components/BulkEditAccessPoints/tests/index.test.js
@@ -72,8 +72,8 @@ const mockProps = {
   tableData: [
     {
       cellSize: [-90, -90, -90],
-      manualChannelNumber: [36, 6, 149],
-      manualBackupChannelNumber: [45, 11, 154],
+      manualChannelNumber: [6, 36, 149],
+      manualBackupChannelNumber: [11, 52, 153],
       clientDisconnectThreshold: [-90, -90, -90],
       id: '1',
       key: '1',
@@ -81,7 +81,58 @@ const mockProps = {
       name: 'AP 1',
       probeResponseThreshold: [-90, -90, -90],
       snrDrop: [30, 30, 20],
-      radioMap: ['is5GHz', 'is2dot4GHz', 'is5GHzL'],
+      radioMap: ['2.4GHz', '5GHz (L)', '5GHz (U)'],
+      allowedChannels: [
+        [
+          {
+            model_type: 'ChannelPowerLevel',
+            channelNumber: 11,
+            powerLevel: 18,
+            dfs: false,
+            channelWidth: 20,
+          },
+          {
+            model_type: 'ChannelPowerLevel',
+            channelNumber: 6,
+            powerLevel: 18,
+            dfs: false,
+            channelWidth: 20,
+          },
+        ],
+        [
+          {
+            model_type: 'ChannelPowerLevel',
+            channelNumber: 153,
+            powerLevel: 18,
+            dfs: false,
+            channelWidth: 80,
+          },
+
+          {
+            model_type: 'ChannelPowerLevel',
+            channelNumber: 149,
+            powerLevel: 18,
+            dfs: false,
+            channelWidth: 80,
+          },
+        ],
+        [
+          {
+            model_type: 'ChannelPowerLevel',
+            channelNumber: 36,
+            powerLevel: 18,
+            dfs: false,
+            channelWidth: 80,
+          },
+          {
+            model_type: 'ChannelPowerLevel',
+            channelNumber: 52,
+            powerLevel: 18,
+            dfs: true,
+            channelWidth: 80,
+          },
+        ],
+      ],
     },
   ],
   onSaveChanges: () => {},
@@ -91,6 +142,7 @@ const mockProps = {
     { id: 2, name: 'Menlo Park' },
     { id: 8, name: 'Ottawa' },
   ],
+  loading: false,
 };
 
 const ENTER = { keyCode: 13 };
@@ -135,6 +187,10 @@ describe('<BulkEditAccessPoints />', () => {
       `bulkEditTableCell-${mockProps.tableData[0].name}-manualChannelNumber`
     );
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-manualChannelNumber`);
+    });
     const input = getByTestId(
       `bulkEditFormInput-${mockProps.tableData[0].name}-manualChannelNumber`
     );
@@ -156,21 +212,25 @@ describe('<BulkEditAccessPoints />', () => {
       `bulkEditTableCell-${mockProps.tableData[0].name}-manualChannelNumber`
     );
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-manualChannelNumber`);
+    });
     const input = getByTestId(
       `bulkEditFormInput-${mockProps.tableData[0].name}-manualChannelNumber`
     );
-    fireEvent.change(input, { target: { value: '166, 0, -1' } });
+    fireEvent.change(input, { target: { value: '7, 36, 149' } });
     fireEvent.keyDown(input, ENTER);
 
     await waitFor(() => {
-      expect(getByText('1 - 165')).toBeVisible();
+      expect(getByText(/allowed channels for/i)).toBeVisible();
     });
 
     fireEvent.change(input, { target: { value: '' } });
     fireEvent.keyDown(input, ENTER);
 
     await waitFor(() => {
-      expect(getByText('1 - 165')).toBeVisible();
+      expect(getByText('Enter Active Channels')).toBeVisible();
     });
   });
 
@@ -185,26 +245,30 @@ describe('<BulkEditAccessPoints />', () => {
       `bulkEditTableCell-${mockProps.tableData[0].name}-manualBackupChannelNumber`
     );
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-manualBackupChannelNumber`);
+    });
     const input = getByTestId(
       `bulkEditFormInput-${mockProps.tableData[0].name}-manualBackupChannelNumber`
     );
-    fireEvent.change(input, { target: { value: '166, 0, -1' } });
+    fireEvent.change(input, { target: { value: '7, 36, 149' } });
     fireEvent.keyDown(input, ENTER);
 
     await waitFor(() => {
-      expect(getByText('1 - 165')).toBeVisible();
+      expect(getByText(/allowed channels for/i)).toBeVisible();
     });
 
     fireEvent.change(input, { target: { value: '' } });
     fireEvent.keyDown(input, ENTER);
 
     await waitFor(() => {
-      expect(getByText('1 - 165')).toBeVisible();
+      expect(getByText('Enter Backup Channels')).toBeVisible();
     });
   });
 
   it('error should be shown if Cell Size input is outside range or empty', async () => {
-    const { getByText, getByTestId } = render(
+    const { getByText, getByTestId, queryByText } = render(
       <Router>
         <BulkEditAccessPoints {...mockProps} />
       </Router>
@@ -212,24 +276,34 @@ describe('<BulkEditAccessPoints />', () => {
 
     const tableCell = getByTestId(`bulkEditTableCell-${mockProps.tableData[0].name}-cellSize`);
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-cellSize`);
+    });
     const input = getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-cellSize`);
     fireEvent.change(input, { target: { value: '-101, 101, 0' } });
     fireEvent.keyDown(input, ENTER);
 
     await waitFor(() => {
-      expect(getByText('-100 - 100')).toBeVisible();
+      expect(getByText('-100 - 0')).toBeVisible();
     });
 
     fireEvent.change(input, { target: { value: '' } });
     fireEvent.keyDown(input, ENTER);
 
     await waitFor(() => {
-      expect(getByText('-100 - 100')).toBeVisible();
+      expect(getByText('-100 - 0')).toBeVisible();
+    });
+
+    fireEvent.change(input, { target: { value: '-90, -90, -90' } });
+
+    await waitFor(() => {
+      expect(queryByText('-100 - 0')).not.toBeInTheDocument();
     });
   });
 
   it('error should be shown if Probe Response Threshold input is outside range or empty', async () => {
-    const { getByText, getByTestId } = render(
+    const { getByText, getByTestId, queryByText } = render(
       <Router>
         <BulkEditAccessPoints {...mockProps} />
       </Router>
@@ -239,6 +313,10 @@ describe('<BulkEditAccessPoints />', () => {
       `bulkEditTableCell-${mockProps.tableData[0].name}-probeResponseThreshold`
     );
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-probeResponseThreshold`);
+    });
     const input = getByTestId(
       `bulkEditFormInput-${mockProps.tableData[0].name}-probeResponseThreshold`
     );
@@ -246,19 +324,25 @@ describe('<BulkEditAccessPoints />', () => {
     fireEvent.keyDown(input, ENTER);
 
     await waitFor(() => {
-      expect(getByText('-100 - 100')).toBeVisible();
+      expect(getByText('-100 - -40')).toBeVisible();
     });
 
     fireEvent.change(input, { target: { value: '' } });
     fireEvent.keyDown(input, ENTER);
 
     await waitFor(() => {
-      expect(getByText('-100 - 100')).toBeVisible();
+      expect(getByText('-100 - -40')).toBeVisible();
+    });
+
+    fireEvent.change(input, { target: { value: '-90, -90, -90' } });
+
+    await waitFor(() => {
+      expect(queryByText('-100 - -40')).not.toBeInTheDocument();
     });
   });
 
   it('error should be shown if Client Disconnect Threshold input is outside range or empty', async () => {
-    const { getByText, getByTestId } = render(
+    const { getByText, getByTestId, queryByText } = render(
       <Router>
         <BulkEditAccessPoints {...mockProps} />
       </Router>
@@ -268,6 +352,10 @@ describe('<BulkEditAccessPoints />', () => {
       `bulkEditTableCell-${mockProps.tableData[0].name}-clientDisconnectThreshold`
     );
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-clientDisconnectThreshold`);
+    });
     const input = getByTestId(
       `bulkEditFormInput-${mockProps.tableData[0].name}-clientDisconnectThreshold`
     );
@@ -275,19 +363,25 @@ describe('<BulkEditAccessPoints />', () => {
     fireEvent.keyDown(input, ENTER);
 
     await waitFor(() => {
-      expect(getByText('-100 - 100')).toBeVisible();
+      expect(getByText('-100 - 0')).toBeVisible();
     });
 
     fireEvent.change(input, { target: { value: '' } });
     fireEvent.keyDown(input, ENTER);
 
     await waitFor(() => {
-      expect(getByText('-100 - 100')).toBeVisible();
+      expect(getByText('-100 - 0')).toBeVisible();
+    });
+
+    fireEvent.change(input, { target: { value: '-90, -90, -90' } });
+
+    await waitFor(() => {
+      expect(queryByText('-100 - 0')).not.toBeInTheDocument();
     });
   });
 
   it('error should be shown if SNR (% Drop) input is outside range or empty', async () => {
-    const { getByText, getByTestId } = render(
+    const { getByText, getByTestId, queryByText } = render(
       <Router>
         <BulkEditAccessPoints {...mockProps} />
       </Router>
@@ -295,6 +389,10 @@ describe('<BulkEditAccessPoints />', () => {
 
     const tableCell = getByTestId(`bulkEditTableCell-${mockProps.tableData[0].name}-snrDrop`);
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-snrDrop`);
+    });
     const input = getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-snrDrop`);
     fireEvent.change(input, { target: { value: '-101, 101, 0' } });
     fireEvent.keyDown(input, ENTER);
@@ -309,10 +407,16 @@ describe('<BulkEditAccessPoints />', () => {
     await waitFor(() => {
       expect(getByText('1 - 100')).toBeVisible();
     });
+
+    fireEvent.change(input, { target: { value: '20, 30, 30' } });
+
+    await waitFor(() => {
+      expect(queryByText('1 - 100')).not.toBeInTheDocument();
+    });
   });
 
   it('error should be shown if Min Load input is outside range or empty', async () => {
-    const { getByText, getByTestId } = render(
+    const { getByText, getByTestId, queryByText } = render(
       <Router>
         <BulkEditAccessPoints {...mockProps} />
       </Router>
@@ -320,6 +424,10 @@ describe('<BulkEditAccessPoints />', () => {
 
     const tableCell = getByTestId(`bulkEditTableCell-${mockProps.tableData[0].name}-minLoad`);
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-minLoad`);
+    });
     const input = getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-minLoad`);
     fireEvent.change(input, { target: { value: '-101, 101, 0' } });
     fireEvent.keyDown(input, ENTER);
@@ -333,6 +441,12 @@ describe('<BulkEditAccessPoints />', () => {
     await waitFor(() => {
       expect(getByText('1 - 100')).toBeVisible();
     });
+
+    fireEvent.change(input, { target: { value: '50, 40, 50' } });
+
+    await waitFor(() => {
+      expect(queryByText('1 - 100')).not.toBeInTheDocument();
+    });
   });
 
   it('error should be shown if any input has an invalid configuration', async () => {
@@ -344,6 +458,10 @@ describe('<BulkEditAccessPoints />', () => {
 
     const tableCell = getByTestId(`bulkEditTableCell-${mockProps.tableData[0].name}-minLoad`);
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-minLoad`);
+    });
     const input = getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-minLoad`);
     fireEvent.change(input, { target: { value: '1,1,1,1,1' } });
     fireEvent.keyDown(input, ENTER);
@@ -364,6 +482,10 @@ describe('<BulkEditAccessPoints />', () => {
       `bulkEditTableCell-${mockProps.tableData[0].name}-manualChannelNumber`
     );
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-manualChannelNumber`);
+    });
     const input = getByTestId(
       `bulkEditFormInput-${mockProps.tableData[0].name}-manualChannelNumber`
     );
@@ -373,12 +495,12 @@ describe('<BulkEditAccessPoints />', () => {
     fireEvent.keyDown(input, ENTER);
 
     await waitFor(() => {
-      expect(getByText('Active and backup channels must be different')).toBeVisible();
+      expect(getByText(/Active and Backup channels/i)).toBeVisible();
     });
   });
 
   it('error should be shown if backup manual channels have same channels as active manual channels', async () => {
-    const { getByText, getByTestId } = render(
+    const { getByText, getByTestId, queryByText } = render(
       <Router>
         <BulkEditAccessPoints {...mockProps} />
       </Router>
@@ -388,6 +510,10 @@ describe('<BulkEditAccessPoints />', () => {
       `bulkEditTableCell-${mockProps.tableData[0].name}-manualBackupChannelNumber`
     );
     fireEvent.click(tableCell);
+
+    await waitFor(() => {
+      getByTestId(`bulkEditFormInput-${mockProps.tableData[0].name}-manualBackupChannelNumber`);
+    });
     const input = getByTestId(
       `bulkEditFormInput-${mockProps.tableData[0].name}-manualBackupChannelNumber`
     );
@@ -397,7 +523,16 @@ describe('<BulkEditAccessPoints />', () => {
     fireEvent.keyDown(input, ENTER);
 
     await waitFor(() => {
-      expect(getByText('Active and backup channels must be different')).toBeVisible();
+      expect(getByText(/Active and Backup channels/i)).toBeVisible();
+    });
+
+    fireEvent.change(input, {
+      target: { value: [...mockProps.tableData[0].manualBackupChannelNumber] },
+    });
+    fireEvent.keyDown(input, ENTER);
+
+    await waitFor(() => {
+      expect(queryByText(/Active and Backup channels/i)).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
NO-JIRA

## Description
*Summary of this PR*

- Added allowedChannels validator to ensure that each channel input for radio is valid
- Added radio column to improve user-experience
- Fixed input ranges for cell-sizing fields to match RF-profile: 
```
- Rx Cell Size: -100 - 100 --> -100 - 0
- Probe Response Threshold: -100 - 100 --> -100 - -40
- Client Disconnect Threshold: 100 - 0 --> -100 - 0
```
- Added skeleton loading instead of spinner

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/126810946-cba00fe5-ec41-4f6a-ba6b-0bc3cb45ddc9.png)

### After this PR
*Screenshots of what it will look like after this PR*

![image](https://user-images.githubusercontent.com/55258316/126810764-68e2b7f2-fd05-4369-901f-2c55826b9c8c.png)
