### PR TITLE
bugfix/WIFI-2842: Deleted IP Lease Start Time Label

### DIFF
--- a/src/containers/ClientDeviceDetails/index.js
+++ b/src/containers/ClientDeviceDetails/index.js
@@ -5,7 +5,7 @@ import { Card, Alert } from 'antd';
 import { LeftOutlined, ReloadOutlined } from '@ant-design/icons';
 import moment from 'moment';
 
-import { formatBytes, formatBitsPerSecond } from 'utils/formatFunctions';
+import { formatBytes, formatBitsPerSecond, durationToString } from 'utils/formatFunctions';
 import Button from 'components/Button';
 import DeviceHistory from 'components/DeviceHistory';
 import ThemeContext from 'contexts/ThemeContext';
@@ -39,27 +39,20 @@ const ClientDeviceDetails = ({
     equipment,
     details,
   } = data;
+  const { dhcpServerIp, primaryDns, secondaryDns, gatewayIp, subnetMask, leaseTimeInSeconds } =
+    details?.dhcpDetails || {};
   const {
-    dhcpServerIp,
-    primaryDns,
-    secondaryDns,
-    gatewayIp,
-    subnetMask,
-    leaseTimeInSeconds,
-    leaseStartTimestamp,
-  } = details?.dhcpDetails || {};
-  const {
-    rssi,
+    rssi = 0,
     rxBytes = 0,
     numTxBytes: txBytes = 0,
     periodLengthSec,
     averageRxRate,
     averageTxRate,
-    numRxFramesReceived,
-    numTxFramesTransmitted,
+    numRxFramesReceived = 0,
+    numTxFramesTransmitted = 0,
   } = latestMetrics?.detailsJSON || {};
-  const rxThroughput = rxBytes / periodLengthSec;
-  const txThroughput = txBytes / periodLengthSec;
+  const rxThroughput = rxBytes / periodLengthSec || 0;
+  const txThroughput = txBytes / periodLengthSec || 0;
   const signal = `${rssi}`;
 
   const status = useMemo(() => {
@@ -76,8 +69,8 @@ const ClientDeviceDetails = ({
     Status: status,
     'Associated On': moment(details?.assocTimestamp).format('llll'),
     'Access Point': equipment?.name,
-    SSID: ssid,
-    'Radio Band': radioTypes?.[radioType],
+    SSID: ssid ?? 'N/A',
+    'Radio Band': radioTypes?.[radioType] ?? 'N/A',
     'Signal Strength': `${signal} dBm`,
     'Tx Rate': `${formatBitsPerSecond(averageTxRate * 1000)}`,
     'Rx Rate': `${formatBitsPerSecond(averageRxRate * 1000)}`,
@@ -92,14 +85,13 @@ const ClientDeviceDetails = ({
   });
 
   const getIpStats = () => ({
-    'IPv4 Address': ipAddress,
-    'DHCP Server': dhcpServerIp,
-    'Primary DNS': primaryDns,
-    'Secondary DNS': secondaryDns,
-    'Gateway ': gatewayIp,
-    'Subnet Mask': subnetMask,
-    'IP Lease Time': leaseTimeInSeconds && `${leaseTimeInSeconds} seconds`,
-    'IP Lease Start': moment(leaseStartTimestamp).format('llll'),
+    'IPv4 Address': ipAddress ?? 'N/A',
+    'DHCP Server': dhcpServerIp ?? 'N/A',
+    'Primary DNS': primaryDns ?? 'N/A',
+    'Secondary DNS': secondaryDns ?? 'N/A',
+    'Gateway ': gatewayIp ?? 'N/A',
+    'Subnet Mask': subnetMask ?? 'N/A',
+    'IP Lease Time': durationToString(moment.duration(leaseTimeInSeconds, 'seconds')),
   });
 
   return (

--- a/src/utils/formatFunctions.js
+++ b/src/utils/formatFunctions.js
@@ -18,6 +18,10 @@ export function bytesLabelFormatter() {
 }
 
 export function formatBitsPerSecond(bps) {
+  if (!bps) {
+    return `0 bps`;
+  }
+
   if (bps >= 1000000000) {
     return `${_.round(bps / 1000000000, 0)} Gbps`;
   }
@@ -55,3 +59,10 @@ export const formatTicks = (firstTs, lastTs, interval) => {
   }
   return [];
 };
+
+export const durationToString = duration =>
+  `${_.floor(duration.asDays())}d ${_.floor(duration.hours())}h ${_.padStart(
+    duration.minutes(),
+    2,
+    0
+  )}m ${_.padStart(duration.seconds(), 2, 0)}s`;


### PR DESCRIPTION
JIRA: [WIFI-2842](https://telecominfraproject.atlassian.net/browse/WIFI-2842)

## Description
*Summary of this PR*

- Deleted IP Lease Start Time Label
- Added null checks to prevent `NaN` labels

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/127023498-cb85b809-4a70-47f2-9a66-f6f3b8118591.png)

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/127023406-d7e1457a-b779-4727-b421-4cae1e261681.png)
