### PR TITLE
NOJIRA: Fixed Upgrade progress bar

### DIFF
--- a/src/containers/AccessPointDetails/components/Firmware/index.js
+++ b/src/containers/AccessPointDetails/components/Firmware/index.js
@@ -109,13 +109,14 @@ const Firmware = ({
   const getRebootStatus = () => updateInProgressStates.has(status?.upgradeState);
 
   const getUpgradePercentage = value => {
+    // In testing, only download_initiated, download_complete, and apply_initiated actually return, the rest are just in case
     if (value.includes('download_initiated')) return 20;
     if (value.includes('download_complete')) return 40;
-    if (value.includes('download')) return 50;
-    if (value.includes('apply_initiated')) return 60;
-    if (value.includes('apply_complete')) return 80;
-    if (value.includes('apply')) return 80;
-    if (value.includes('reboot')) return 90;
+    if (value.includes('download')) return 70;
+    if (value.includes('apply_initiated')) return 80;
+    if (value.includes('apply_complete')) return 90;
+    if (value.includes('apply')) return 90;
+    if (value.includes('reboot')) return 95;
     return 100;
   };
 


### PR DESCRIPTION
NOJIRA

## Description
Wed Aug 4
- Tweak percentages so that the upgrade progress bar is more smooth since it only really is in three stages during the upgrade. Now user will see 20%, 40%, and 80% before completing

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*