### PR TITLE
bugfix/NOJIRA-AutoUpdatePackage 

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,30 @@
+name: 'Bump Version'
+
+on:
+  push:
+    branches:
+      - "master"
+    paths-ignore: 
+      - "**/package.json"
+      - "**/package-lock.json"
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - name: Bump Version
+        run: |
+          git config -- global user.name "GH Action"
+          npm version patch -m "bump version"
+      - name: Push to protected branch
+        uses: CasperWA/push-protected@v2
+          with:
+            token: ${{ secrets.PUSH_TO_PROTECTED_BRANCH }}
+            branch: master
+            unprotect_reviews: true


### PR DESCRIPTION

## Description
*Summary of this PR*

- Auto updates the package version on push
- used a package that bypasses protected repos

**For this to work**:

1. On Github click the icon in top right and go to `settings` 
2. On the left side click `developer settings` then >  `Personal Access Tokens`
3. Click Generate new token. I named it `PUSH_TO_PROTECTED_BRANCH` 
4. Give it these scopes: 
![image](https://user-images.githubusercontent.com/73356579/129619049-06a37b7d-448c-4e2a-a3ce-9687dd6d94f6.png)
5. Click Update Token and copy the key 
5. back into the Repo now and go to Settings > Secrets > New repository secret
6. name: `PUSH_TO_PROTECTED_BRANCH`, value: `<> the token key that was generated  </>`
