### PR TITLE
hotfix/ApProfileVLAN: Removed Management VLAN input from AP profile

### DIFF
--- a/src/containers/ProfileDetails/components/AccessPoint/index.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/index.js
@@ -128,8 +128,6 @@ const AccessPointForm = ({
     );
 
     form.setFieldsValue({
-      vlanNative: details?.vlanNative === undefined ? true : details?.vlanNative,
-      vlan: details?.vlan || DEFAULT_AP_PROFILE.vlan,
       ntpServer: {
         auto: details?.ntpServer?.auto ?? DEFAULT_AP_PROFILE.ntpServer.auto,
       },
@@ -380,54 +378,7 @@ const AccessPointForm = ({
 
   return (
     <div className={styles.ProfilePage}>
-      <Card title="LAN and Services " loading={loading}>
-        <Item label="Management VLAN" valuePropName="checked" name="vlanNative">
-          <Checkbox data-testid="vlanCheckbox">Use Default Management VLAN</Checkbox>
-        </Item>
-        <Item
-          noStyle
-          shouldUpdate={(prevValues, currentValues) =>
-            prevValues.vlanNative !== currentValues.vlanNative
-          }
-        >
-          {({ getFieldValue }) => {
-            return (
-              !getFieldValue('vlanNative') && (
-                <Item
-                  wrapperCol={{ offset: 5, span: 15 }}
-                  name="vlan"
-                  rules={[
-                    {
-                      required: true,
-                      message: 'VLAN expected between 2 and 4095',
-                    },
-                    () => ({
-                      validator(_rule, value) {
-                        if (
-                          !value ||
-                          (getFieldValue('vlan') <= 4095 && getFieldValue('vlan') > 1)
-                        ) {
-                          return Promise.resolve();
-                        }
-                        return Promise.reject(new Error('VLAN expected between 2 and 4095'));
-                      },
-                    }),
-                  ]}
-                  hasFeedback
-                >
-                  <Input
-                    data-testid="vlanInput"
-                    placeholder="2-4095"
-                    type="number"
-                    min={2}
-                    max={4095}
-                    maxLength={4}
-                  />
-                </Item>
-              )
-            );
-          }}
-        </Item>
+      <Card title="LAN and Services" loading={loading}>
         <Item label="NTP" name={['ntpServer', 'auto']} valuePropName="checked">
           <Checkbox data-testid="ntpCheckbox">Use Default Servers</Checkbox>
         </Item>

--- a/src/containers/ProfileDetails/components/AccessPoint/tests/index.test.js
+++ b/src/containers/ProfileDetails/components/AccessPoint/tests/index.test.js
@@ -96,48 +96,6 @@ describe('<AccessPoints />', () => {
     render(<AccessPointComp />);
   });
 
-  it('uncheck Use Default Management VLAN should show the input field for vlan value', () => {
-    const AccessPointComp = () => {
-      const [form] = Form.useForm();
-      return <AccessPoints {...mockAccessPoint} form={form} />;
-    };
-    const { getByTestId } = render(<AccessPointComp />);
-
-    const checkbox = getByTestId('vlanCheckbox');
-    fireEvent.click(checkbox);
-    expect(checkbox.checked).toEqual(false);
-    expect(getByTestId('vlanInput')).toBeInTheDOM();
-  });
-
-  it('error message should be displayed if input value for vlan is invalid', async () => {
-    const AccessPointComp = () => {
-      const [form] = Form.useForm();
-      return (
-        <Form form={form}>
-          <AccessPoints {...mockAccessPoint} form={form} />
-        </Form>
-      );
-    };
-
-    const { getByTestId, getByPlaceholderText, getByText } = render(<AccessPointComp />);
-
-    const checkbox = getByTestId('vlanCheckbox');
-    fireEvent.click(checkbox);
-    expect(checkbox.checked).toEqual(false);
-    const vlanInput = getByTestId('vlanInput');
-    expect(vlanInput).toBeInTheDOM();
-    fireEvent.change(getByPlaceholderText('2-4095'), {
-      target: { value: 2 },
-    });
-    fireEvent.change(getByPlaceholderText('2-4095'), {
-      target: { value: '123456' },
-    });
-    expect(vlanInput.value).toBe('123456');
-    await waitFor(() => {
-      expect(getByText('VLAN expected between 2 and 4095')).toBeVisible();
-    });
-  });
-
   it('uncheck Use Default Servers should show the input field for NTP value', async () => {
     const AccessPointComp = () => {
       const [form] = Form.useForm();


### PR DESCRIPTION
NO-JIRA

## Description
*Summary of this PR*
Removed unsupported input -  `Management VLAN `from AP Profile

### Before this PR
*Screenshots of what it looked like before this PR*
![image](https://user-images.githubusercontent.com/55258316/130250722-5e40b912-616f-4f00-b153-c029d1dbe669.png)


### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/130250615-30eeb909-e7d5-4540-8bf8-f5385a336443.png)
