### PR TITLE
hotfix/ApDetailsFirmware: Disable 'switch to inactive bank' button

### DIFF
--- a/src/containers/AccessPointDetails/components/Firmware/index.js
+++ b/src/containers/AccessPointDetails/components/Firmware/index.js
@@ -164,7 +164,7 @@ const Firmware = ({
               className={styles.UpgradeState}
               icon={<LoginOutlined />}
               onClick={handleOnSwitchInactiveBank}
-              disabled={status.alternateSwVersion === status.activeSwVersion || getRebootStatus()}
+              disabled
             >
               Switch to Inactive Bank and Reboot
             </RoleProtectedBtn>


### PR DESCRIPTION
NO-JIRA

## Description
*Summary of this PR*
Disabled  'switch to inactive bank' button on AP Details Firmware page as it is currently unsupported

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*
![image](https://user-images.githubusercontent.com/55258316/130251888-9d6de86e-3dc1-4346-a455-74cf30b91606.png)
