### PR TITLE
bugfix/NOJIRA: fixed loading datasource to be array of objs

### DIFF
--- a/src/components/Skeleton/index.js
+++ b/src/components/Skeleton/index.js
@@ -65,7 +65,15 @@ export const Table = ({ loading, columns, dataSource, onRow, ...props }) => {
     <AntdTable
       {...props}
       loading={false}
-      dataSource={loading ? [...Array(15).map((_, index) => ({ key: `key${index}` }))] : dataSource}
+      dataSource={
+        loading
+          ? [
+              ...Array(15)
+                .fill()
+                .map((_, index) => ({ key: `key${index}`, id: `key${index}` })),
+            ]
+          : dataSource
+      }
       columns={
         loading
           ? columns.map(column => {


### PR DESCRIPTION
JIRA: NO-JIRA

## Description
*Summary of this PR*
bug: with undefined row key error for all tables
cause: Array of undefined was generated instead of an array of objects
solution: fixed by filling with fill()

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*