### PR TITLE
NOJIRA: Pie Chart Overlap Fix

### DIFF
--- a/src/containers/Dashboard/components/PieChart/index.js
+++ b/src/containers/Dashboard/components/PieChart/index.js
@@ -31,18 +31,24 @@ const MyPieChart = ({ chartData, title, loading, chartTextColor }) => {
     />
   );
 
-  const renderLabel = ({ name, x, y, cx }) => (
-    <text
-      x={x}
-      y={y}
-      fill={chartTextColor}
-      dominantBaseline="central"
-      textAnchor={x > cx ? 'start' : 'end'}
-      style={{ fontSize: '12px' }}
-    >
-      {name}
-    </text>
-  );
+  const renderLabel = ({ name, x, y, cx, index, percent }) => {
+    const label = (
+      <text
+        x={x}
+        y={y}
+        fill={chartTextColor}
+        dominantBaseline="central"
+        textAnchor={x > cx ? 'start' : 'end'}
+        style={{ fontSize: '14px' }}
+      >
+        {name}
+      </text>
+    );
+    if (activeIndex) {
+      return activeIndex === index ? label : null;
+    }
+    return percent > 0.05 ? label : null;
+  };
 
   return (
     <Card title={title}>
@@ -54,6 +60,7 @@ const MyPieChart = ({ chartData, title, loading, chartTextColor }) => {
                 dataKey="value"
                 data={pieData}
                 label={renderLabel}
+                labelLine={false}
                 activeIndex={activeIndex}
                 onMouseOver={onMouseOver}
                 onMouseLeave={onMouseLeave}


### PR DESCRIPTION
NOJIRA

## Description

- Prevent pie chart labels from overlapping by only showing labels if they slice is more than 5%

### Before this PR
*Screenshots of what it looked like before this PR*

### After this PR
*Screenshots of what it will look like after this PR*